### PR TITLE
Sg/54 valueerror in qutipbackend evaluation time list extends beyond sequence duration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ classifiers = [
 
 
 dependencies = [
-  "pulser==1.5.5",
-  "matplotlib",
+  "pulser==1.5.6",
   "networkx==3.4.2",
+  "matplotlib",
   "emu_mps"
 ]
 

--- a/qoolqit/embedding/algorithms/interaction_embedding.py
+++ b/qoolqit/embedding/algorithms/interaction_embedding.py
@@ -53,7 +53,7 @@ def interaction_embedding(matrix: np.ndarray, method: str, maxiter: int, tol: fl
         args=(matrix,),
         method=method,
         tol=tol,
-        options={"maxiter": maxiter, "maxfev": None},
+        options={"maxiter": maxiter},
     )
 
     coords = np.reshape(res.x, (len(matrix), 2))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import reduce
 from math import pi
-from random import randint, seed, uniform
+from random import randint, uniform
 from typing import Callable, Generator
 
 import numpy as np
@@ -13,9 +13,6 @@ from qoolqit.drive import Drive
 from qoolqit.program import QuantumProgram
 from qoolqit.register import Register
 from qoolqit.waveforms import Ramp, Waveform
-
-# TODO: remove fixing seed after pulser updates to 1.6
-seed(99)
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #54 

- minimal bug example provided in the issue now works fine
- qubo tutorial with `profile=Profile.MIN_DISTANCE` also works
- no more randomly failing pipeline tests

### Changes
- fix pulser to 1.5.6
- remove seed from tests
- remove unused kwarg in `scipy.optimize` which was causing warnings in tests