### PR TITLE
pulser bump 1.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     name: Run unit/integration tests
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -45,28 +45,3 @@ jobs:
         name: "coverage-data"
         path: .coverage.*
         if-no-files-found: ignore
-
-  test_qoolqit_windows:
-    # Windows requires its own syntax for testing Notebooks,
-    # to be implemented.
-    name: Run unit/integration tests (Windows)
-    strategy:
-      matrix:
-        os: [windows-latest]
-        python-version: ["3.10", "3.13"] # Testing with fewer versions as Windows tests are slow.
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout QoolQit
-      uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Hatch
-      # Workaround for hatch crash - install click==8.2.1
-      run: |
-        pip install hatch
-        pip install click==8.2.1
-    - name: Run tests & tutorials
-      run: |
-        hatch -v run test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 
 dependencies = [
-  "pulser~=1.5",
+  "pulser~=1.6.1",
   "networkx~=3.4",
   "matplotlib",
   "emu_mps"
@@ -54,7 +54,7 @@ solvers = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/pasqal-io/qoolqit" # FIXME
+Documentation = "https://pasqal-io.github.io/qoolqit/latest"
 Issues = "https://github.com/pasqal-io/qoolqit/issues"
 Source = "https://github.com/pasqal-io/qoolqit"
 
@@ -119,7 +119,7 @@ serve = "mkdocs serve --dev-addr localhost:8000"
 test = "mkdocs build --clean --strict"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["310", "311", "312"]
+python = ["310", "311", "312", "313"]
 
 [tool.hatch.build.targets.sdist]
 exclude = [

--- a/qoolqit/_solvers/backends/__init__.py
+++ b/qoolqit/_solvers/backends/__init__.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import os
-
 from .base_backend import BaseBackend
 from .get_backend import get_backend
-from .local_backends import BaseLocalBackend, QutipBackend
+from .local_backends import BaseLocalBackend, EmuMPSBackend, EmuSVBackend, QutipBackend
 from .remote_backends import (
     BaseRemoteBackend,
     RemoteEmuFREEBackend,
@@ -25,12 +23,6 @@ __all__ = [
     "RemoteEmuFREEBackend",
     "get_backend",
     "RemoteJob",
+    "EmuMPSBackend",
+    "EmuSVBackend",
 ]
-
-if os.name == "posix":
-    from .local_backends import EmuMPSBackend, EmuSVBackend
-
-    __all__ += [
-        "EmuMPSBackend",
-        "EmuSVBackend",
-    ]

--- a/qoolqit/_solvers/backends/get_backend.py
+++ b/qoolqit/_solvers/backends/get_backend.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import logging
-import os
 from typing import cast
 
 from qoolqit._solvers.types import BackendType
 
 from .base_backend import BackendConfig, BaseBackend
-from .local_backends import QutipBackend
+from .local_backends import EmuMPSBackend, EmuSVBackend, QutipBackend
 from .remote_backends import (
     RemoteEmuFREEBackend,
     RemoteEmuMPSBackend,
@@ -15,37 +13,15 @@ from .remote_backends import (
     RemoteQPUBackend,
 )
 
-logger = logging.getLogger(__name__)
-
-
-portable_backends_map: dict[BackendType, type[BaseBackend]] = {
+backends_map: dict[BackendType, type[BaseBackend]] = {
     BackendType.QUTIP: cast(type[BaseBackend], QutipBackend),
+    BackendType.EMU_MPS: cast(type[BaseBackend], EmuMPSBackend),
+    BackendType.EMU_SV: cast(type[BaseBackend], EmuSVBackend),
     BackendType.REMOTE_EMUMPS: cast(type[BaseBackend], RemoteEmuMPSBackend),
     BackendType.REMOTE_QPU: cast(type[BaseBackend], RemoteQPUBackend),
     BackendType.REMOTE_EMUFREE: cast(type[BaseBackend], RemoteEmuFREEBackend),
     BackendType.REMOTE_EMUTN: cast(type[BaseBackend], RemoteEmuTNBackend),
 }
-"""The backends available on all platforms."""
-
-if os.name == "posix":
-    from .local_backends import EmuMPSBackend, EmuSVBackend
-
-    posix_backends_map: dict[BackendType, type[BaseBackend]] = {
-        BackendType.EMU_MPS: cast(type[BaseBackend], EmuMPSBackend),
-        BackendType.EMU_SV: cast(type[BaseBackend], EmuSVBackend),
-    }
-    """The backends available only on Posix platforms."""
-    backends_map: dict[BackendType, type[BaseBackend]] = portable_backends_map.copy()
-    for k, v in posix_backends_map.items():
-        backends_map[k] = v
-    unavailable_backends_map = {}
-    """The backends not available on this platform."""
-else:
-    backends_map = portable_backends_map
-    unavailable_backends_map = {
-        BackendType.EMU_MPS: cast(type[BaseBackend], None),
-        BackendType.EMU_SV: cast(type[BaseBackend], None),
-    }
 
 
 def get_backend(backend_config: BackendConfig) -> BaseBackend:
@@ -53,13 +29,10 @@ def get_backend(backend_config: BackendConfig) -> BaseBackend:
     Instantiate a backend.
 
     # Concurrency note
-
     Backends are *not* meant to be shared across threads.
     """
     backend = backends_map.get(backend_config.backend, None)
     if backend is not None:
         return backend(backend_config)
-    if backend_config.backend in unavailable_backends_map:
-        raise ValueError(f"Backend {backend_config.backend} is not available on {os.name}.")
     else:
         raise ValueError(f"Unknown backend {backend_config.backend}.")

--- a/qoolqit/execution/__init__.py
+++ b/qoolqit/execution/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import os
-
-from .backend import QutipBackend
+from .backend import EmuMPSBackend, QutipBackend
 from .backends import QPU, LocalEmulator, RemoteEmulator
 from .sequence_compiler import SequenceCompiler
 from .utils import BackendName, CompilerProfile, ResultType
@@ -16,9 +14,5 @@ __all__ = [
     "LocalEmulator",
     "RemoteEmulator",
     "QPU",
+    "EmuMPSBackend",
 ]
-
-if os.name == "posix":
-    from .backend import EmuMPSBackend
-
-    __all__ += ["EmuMPSBackend"]

--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 from warnings import warn
 
@@ -9,7 +8,7 @@ from pulser.sequence.sequence import Sequence as PulserSequence
 
 from qoolqit.devices import Device, MockDevice
 from qoolqit.drive import Drive
-from qoolqit.execution.backend import BaseBackend, OutputType, QutipBackend
+from qoolqit.execution.backend import BaseBackend, EmuMPSBackend, OutputType, QutipBackend
 from qoolqit.execution.sequence_compiler import SequenceCompiler
 from qoolqit.execution.utils import BackendName, CompilerProfile, ResultType
 from qoolqit.register import Register
@@ -151,13 +150,9 @@ class QuantumProgram:
                 backend = QutipBackend(self._compiled_sequence, result_type, **backend_params)
                 return backend.run(runs, evaluation_times)
             elif backend_name == BackendName.EMUMPS:
-                if os.name == "posix":
-                    from qoolqit.execution.backend import EmuMPSBackend
+                backend = EmuMPSBackend(self._compiled_sequence, result_type, **backend_params)
+                return backend.run(runs, evaluation_times)
 
-                    backend = EmuMPSBackend(self._compiled_sequence, result_type, **backend_params)
-                    return backend.run(runs, evaluation_times)
-                else:
-                    raise NotImplementedError("EmuMPS is only available on Unix platforms")
             else:
                 raise ValueError(f"Invalid backend {backend_name}")
         else:

--- a/tests/test_execution/test_backend.py
+++ b/tests/test_execution/test_backend.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Callable
 
 import numpy as np
@@ -17,7 +16,7 @@ from qoolqit.execution import BackendName, ResultType
 def test_theoretical_state_vector(
     backend_name: BackendName, random_x_rotation: np.ndarray, random_rotation_angle: float
 ) -> None:
-    if backend_name == BackendName.EMUMPS and os.name != "posix":
+    if backend_name == BackendName.EMUMPS:
         pytest.skip("EmuMPS is only available under Unix")
         return
 
@@ -36,7 +35,6 @@ def test_theoretical_state_vector(
     assert np.isclose(theor_state, res, atol=ATOL_STATE_VEC).all()
 
 
-@pytest.mark.skipif(os.name != "posix", reason="EmuMPS is currently available only under Unix")
 @pytest.mark.parametrize(
     "backend_name, device",
     [
@@ -61,7 +59,6 @@ def test_state_vector(random_program: Callable, backend_name: BackendName, devic
     assert np.isclose(qutip_res, bknd_res, atol=ATOL_STATE_VEC).all()
 
 
-@pytest.mark.skipif(os.name != "posix", reason="EmuMPS is currently available only under Unix")
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize(
     "backend_name, device",
@@ -117,14 +114,7 @@ def test_bitstrings(random_program: Callable, backend_name: BackendName, device:
     "backend_name",
     [
         pytest.param(BackendName.QUTIP),
-        pytest.param(
-            BackendName.EMUMPS,
-            marks=[
-                pytest.mark.skipif(
-                    os.name != "posix", reason="EmuMPS is currently available only under Unix"
-                )
-            ],
-        ),
+        pytest.param(BackendName.EMUMPS),
     ],
 )
 @pytest.mark.parametrize("result_type", [ResultType.STATEVECTOR, ResultType.BITSTRINGS])

--- a/tests/test_solvers/test_qoolqit_backends.py
+++ b/tests/test_solvers/test_qoolqit_backends.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import datetime
 import json
-import os
 import random
 import re
 from typing import Any, Callable, Counter, cast
@@ -19,6 +18,8 @@ from pulser.waveforms import Waveform
 from qoolqit._solvers import (
     BaseBackend,
     Detuning,
+    EmuMPSBackend,
+    EmuSVBackend,
     QutipBackend,
     RemoteEmuFREEBackend,
     RemoteEmuMPSBackend,
@@ -53,14 +54,9 @@ def make_simple_program(backend: BaseBackend) -> QuantumProgram:
 
 local_backends: list[tuple[type[BaseBackend], BackendType]] = [
     (QutipBackend, BackendType.QUTIP),
+    (EmuMPSBackend, BackendType.EMU_MPS),
+    (EmuSVBackend, BackendType.EMU_SV),
 ]
-if os.name == "posix":
-    from qoolqit._solvers import EmuMPSBackend, EmuSVBackend
-
-    local_backends += [
-        (EmuMPSBackend, BackendType.EMU_MPS),
-        (EmuSVBackend, BackendType.EMU_SV),
-    ]
 
 remote_backends: list[tuple[type[BaseBackend], BackendType]] = [
     (RemoteEmuMPSBackend, BackendType.REMOTE_EMUMPS),


### PR DESCRIPTION
bump pulser to ~1.6.1

### Changes
- bump pulser
- automatically bump to emu-mps/sv 2.4 (they now support windows)
- clean `os.posix` logic introduced in #66 to fix emulators not supporting windows