### PR TITLE
update pipeline jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install QoolQit with development dependencies
-      run: pip install -e .[dev]
-    - name: Run docs building
-      run: mkdocs build --clean --strict
+      run: |
+        pip install -e .[dev]
+    - name: Build docs
+      run: |
+        mkdocs build --clean --strict

--- a/.github/workflows/docs_development.yml
+++ b/.github/workflows/docs_development.yml
@@ -27,7 +27,8 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install QoolQit with development dependencies
-      run: pip install -e .[dev]
+      run: |
+        pip install -e .[dev]
     - name: Deploy docs
       run: |
         git config user.name "GitHub Actions"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
-name: Publish QoolQit to PyPI
+name: Publish QoolQit to PyPI and publish docs
 
 on:
-    release:
-        types:
-            [published]
+  release:
+      types:
+        - published
 
 concurrency:
   group: fast-${{ github.head_ref || github.run_id }}
@@ -30,7 +30,8 @@ jobs:
             pip install --upgrade pip
             pip install build
         - name: Build package
-          run: python -m build
+          run: |
+            python -m build
         - name: Publish to PyPI
           uses: pypa/gh-action-pypi-publish@release/v1
         - name: Confirm deployment
@@ -62,7 +63,8 @@ jobs:
           with:
             python-version: '3.12'
         - name: Install QoolQit with development dependencies
-          run: pip install -e .[dev]
+          run: |
+            pip install -e .[dev]
         - name: Deploy docs
           run: |
             git config user.name "GitHub Actions"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test_qoolqit:
-    name: Run unit/integration tests
+    name: Run tests
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -31,7 +31,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install QoolQit with development dependencies
-      run: pip install -e .[dev]
+      run: |
+        pip install -e .[dev]
     - name: Run tests & tutorials
       run: |
         pytest -vvv --cov-report=term-missing --cov-config=pyproject.toml --cov=qoolqit --markdown-docs


### PR DESCRIPTION
Resolve #182 

## Description
A small issue in hatch prevents from running hatch scripts in pipeline with `virtualenv==21.0.0`. 
Since our pipeline is very easy, just replace hatch scripts with equivalent one with `pytest` and `mkdocs`.

## Changes
- replace hatch in pipeline with equivalent scripts