### PR TITLE
graph drawing only manipulate axis

### DIFF
--- a/docs/contents/available_embedders.md
+++ b/docs/contents/available_embedders.md
@@ -65,22 +65,17 @@ print(embedder)
 Finally, we can run the embedder with the `embed` method.
 
 ```python exec="on" source="material-block" html="1" session="embedding"
+import matplotlib.pyplot as plt
 from qoolqit import DataGraph
 
 graph_1 = DataGraph.random_er(n = 7, p = 0.3, seed = 3)
-
 embedded_graph_1 = embedder.embed(graph_1)
 
-graph_1.draw()
-embedded_graph_1.draw()
-
-import matplotlib.pyplot as plt # markdown-exec: hide
+fig, axs = plt.subplots(1, 2, figsize=(8,4), dpi=200)
+graph_1.draw(ax=axs[0])
+embedded_graph_1.draw(ax=axs[1])
 from docs.utils import fig_to_html # markdown-exec: hide
-
-fig1 = graph_1.draw(return_fig = True) # markdown-exec: hide
-fig2 = embedded_graph_1.draw(return_fig = True) # markdown-exec: hide
-print(fig_to_html(fig1)) # markdown-exec: hide
-print(fig_to_html(fig2)) # markdown-exec: hide
+print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
 Now, we can check if the resulting graph is a unit-disk graph
@@ -94,19 +89,13 @@ In this case, the embedding was successful and we obtained a unit-disk graph. Fo
 
 ```python exec="on" source="material-block" html="1" session="embedding"
 graph_2 = DataGraph.random_er(n = 7, p = 0.8, seed = 3)
-
 embedded_graph_2 = embedder.embed(graph_2)
 
-graph_2.draw()
-embedded_graph_2.draw()
-
-import matplotlib.pyplot as plt # markdown-exec: hide
+fig, axs = plt.subplots(1, 2, figsize=(8,4), dpi=200)
+graph_2.draw(ax=axs[0])
+embedded_graph_2.draw(ax=axs[1])
 from docs.utils import fig_to_html # markdown-exec: hide
-
-fig1 = graph_2.draw(return_fig = True) # markdown-exec: hide
-fig2 = embedded_graph_2.draw(return_fig = True) # markdown-exec: hide
-print(fig_to_html(fig1)) # markdown-exec: hide
-print(fig_to_html(fig2)) # markdown-exec: hide
+print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
 ```python exec="on" source="material-block" result="json" session="embedding"
@@ -182,13 +171,11 @@ Finally, running the embedding we obtain a `DataGraph` with coordinates that can
 import numpy as np
 
 embedded_graph = embedder.embed(matrix)
-
 register = Register.from_graph(embedded_graph)
 
-embedded_graph.draw()
+fig1, ax1 = plt.subplots(figsize=(4,4), dpi=200)
+embedded_graph.draw(ax=ax1)
 register.draw()
-
-fig1 = embedded_graph.draw(return_fig = True) # markdown-exec: hide
 fig2 = register.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig1)) # markdown-exec: hide
 print(fig_to_html(fig2)) # markdown-exec: hide

--- a/docs/contents/graphs.md
+++ b/docs/contents/graphs.md
@@ -38,8 +38,8 @@ from docs.utils import fig_to_html # markdown-exec: hide
 
 pos = nx.circular_layout(graph)
 
-graph.draw(pos = pos)
-fig = graph.draw(pos = pos, return_fig = True) # markdown-exec: hide
+fig, ax = plt.subplots(figsize=(4,4), dpi=200)  # markdown-exec: hide
+graph.draw(pos=pos)
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -89,8 +89,9 @@ Furthermore, when calling `graph.draw()` the coordinate information will be auto
 ```python exec="on" source="material-block" html="1" session="graphs"
 import matplotlib.pyplot as plt # markdown-exec: hide
 from docs.utils import fig_to_html # markdown-exec: hide
+
+fig, ax = plt.subplots(figsize=(4,4), dpi=200)  # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -211,8 +212,8 @@ graph.set_ud_edges(radius = 1.0)
 
 assert len(graph.edges) > 0
 
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -223,8 +224,8 @@ A line graph on n nodes.
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.line(n = 10, spacing = 1.0)
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -233,8 +234,8 @@ A circle graph on n nodes.
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.circle(n = 10, spacing = 1.0, center = (0.0, 0.0))
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -243,8 +244,8 @@ A triangular lattice graph with m rows and n columns of triangles.
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.triangular(m = 2, n = 2, spacing = 1.0)
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -253,8 +254,8 @@ A square lattice graph with m rows and n columns of square.
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.square(m = 2, n = 2, spacing = 1.0)
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -263,8 +264,8 @@ A Hexagonal lattice graph with m rows and n columns of hexagons.
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.hexagonal(m = 2, n = 2, spacing = 1.0)
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -273,8 +274,8 @@ An Heavy-Hexagonal lattice graph with m rows and n columns of hexagons where eac
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.heavy_hexagonal(m = 2, n = 2, spacing = 1.0)
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -283,8 +284,8 @@ A random unit-disk graph by uniformly sampling points in area of side L.
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.random_ud(n = 10, radius = 1.0, L = 2.0)
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
@@ -295,8 +296,8 @@ A random Erdős–Rényi graph of n nodes.
 
 ```python exec="on" source="material-block" html="1" session="graph-constructors"
 graph = DataGraph.random_er(n = 10, p = 0.5, seed = 1)
+fig, ax = plt.subplots(figsize=(4,4), dpi=200) # markdown-exec: hide
 graph.draw()
-fig = graph.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Quantum programs: contents/programs.md
       - Execution: contents/execution.md
   - Tutorials:
+    - User journey: tutorials/user_journey.ipynb
     - Solving a basic QUBO: tutorials/basic_qubo.ipynb
     - Defining a custom quantum program: tutorials/custom_quantum_program.ipynb
     - Advanced:

--- a/qoolqit/graphs/base_graph.py
+++ b/qoolqit/graphs/base_graph.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import matplotlib.pyplot as plt
 import networkx as nx
 import torch
-from matplotlib.figure import Figure
+from matplotlib.axes import Axes
 
 from .utils import (
     all_node_pairs,
@@ -418,28 +418,26 @@ class BaseGraph(nx.Graph):
         self.remove_edges_from(list(self.edges))
         self.add_edges_from(self.ud_edges(radius))
 
-    def draw(self, return_fig: bool = False, *args: Any, **kwargs: Any) -> Figure | None:
+    def draw(self, ax: Axes | None = None, **kwargs: Any) -> None:
         """Draw the graph.
 
         Uses the draw_networkx function from NetworkX.
 
-        Arguments:
-            *args: arguments to pass to draw_networkx.
+        Args:
+            ax: Axes object to draw on. If None, uses the current Axes.
             **kwargs: keyword-arguments to pass to draw_networkx.
         """
-        fig, ax = plt.subplots(figsize=(4, 4), dpi=250)
-        ax.set_aspect("equal")
         if self.has_coords:
-            ax.set_xlabel("x")
-            ax.set_ylabel("y")
-            ax.grid(True, color="lightgray", linestyle="--", linewidth=0.7)
-            ax.tick_params(direction="in")
-            ax.set_axisbelow(True)
-
             if "hide_ticks" not in kwargs:
                 kwargs["hide_ticks"] = False
 
-            nx.draw_networkx(self, *args, ax=ax, pos=self.coords, **kwargs)
+            nx.draw_networkx(self, pos=self.coords, ax=ax, **kwargs)
+
+            if ax is None:
+                ax = plt.gca()
+            ax.set_xlabel("x")
+            ax.set_ylabel("y")
+            ax.grid(True, color="lightgray", linestyle="--", linewidth=0.7)
 
             # minimum ybox
             ylim = ax.get_ylim()
@@ -448,10 +446,4 @@ class BaseGraph(nx.Graph):
                 ax.set_ylim(y_center - 1, y_center + 1)
             plt.tight_layout()
         else:
-            nx.draw_networkx(self, *args, ax=ax, **kwargs)
-
-        if return_fig:
-            plt.close()
-            return fig
-        else:
-            return None
+            nx.draw_networkx(self, ax=ax, **kwargs)


### PR DESCRIPTION
figsize is currently hardcoded to (4,4). A more flexible approach is to manipulate `matplotlib` axis.

This MR allows defining the figure beforehand:
```pyhton
fig, ax = plt.subplots(figsize=(4,2))
graph.draw(ax=ax)
```
## Changes
- remove `return_fig` kwarg in `DataGraph.draw()`. Not ideal since it does not allow manipulating the figure once created.
- many repetitive changes in the docs since the above path was used to generate the figures. An equivalent way is provided. The new code in the markdown cells works otherwise the docs job in the pipeline would fail.
