### PR TITLE
add breaking compilation section

### DIFF
--- a/docs/fundamentals/compilation/device_and_compilation.md
+++ b/docs/fundamentals/compilation/device_and_compilation.md
@@ -110,7 +110,7 @@ print(fig_to_html(fig_compiled)) # markdown-exec: hide
 Whenever possible, the compilation step in QoolQit will simply take care of mapping the input quantum program into real hardware instructions.
 In other words, ratios between energies (interactions and drive) and time will be preserved (see [compilation rationale](./rationale.md)).
 However, in some applications, one may be interested in separating time from the compilation step.
-For example, in adiabatic protocols, one simply seek to rescale the duration of a quantum program to the maximum value allowed by the specific hardware.
+For example, in adiabatic protocols, one simply seeks to rescale the duration of a quantum program to the maximum value allowed by the specific hardware.
 
 To do so, set the corresponding flag at compilation:
 

--- a/docs/fundamentals/compilation/device_and_compilation.md
+++ b/docs/fundamentals/compilation/device_and_compilation.md
@@ -106,9 +106,9 @@ print(fig_to_html(fig_compiled)) # markdown-exec: hide
 ```
 
 
-## Breaking compilation
+## Special compilation: maximum allowed duration
 Whenever possible, the compilation step in QoolQit will simply take care of mapping the input quantum program into real hardware instructions.
-In other words, ratios between energies (interactions and drive) and time will be preserved.
+In other words, ratios between energies (interactions and drive) and time will be preserved (see [compilation rationale](./rationale.md)).
 However, in some applications, one may be interested in separating time from the compilation step.
 For example, in adiabatic protocols, one simply seek to extend the duration of a quantum program to the maximum allowed value by the specific hardware.
 
@@ -119,3 +119,12 @@ It is important to highlight that:
     The same program compiled on two different devices will be different.
 
 As anticipated, this flag will decouple time from the compilation, letting the user set a time relative to the maximum allowed by the selected device.
+To use it, simply use the corresponding flag at compilation:
+
+```python exec="on" source="material-block" html="1" session="drives"
+# Compilation to AnalogDevice max duration
+program.compile_to(device, device_max_duration_ratio=1.0)
+program.draw(compiled = True)
+fig_compiled = program.draw(compiled = True, return_fig = True) # markdown-exec: hide
+print(fig_to_html(fig_compiled)) # markdown-exec: hide
+```

--- a/docs/fundamentals/compilation/device_and_compilation.md
+++ b/docs/fundamentals/compilation/device_and_compilation.md
@@ -110,16 +110,9 @@ print(fig_to_html(fig_compiled)) # markdown-exec: hide
 Whenever possible, the compilation step in QoolQit will simply take care of mapping the input quantum program into real hardware instructions.
 In other words, ratios between energies (interactions and drive) and time will be preserved (see [compilation rationale](./rationale.md)).
 However, in some applications, one may be interested in separating time from the compilation step.
-For example, in adiabatic protocols, one simply seek to extend the duration of a quantum program to the maximum allowed value by the specific hardware.
+For example, in adiabatic protocols, one simply seek to rescale the duration of a quantum program to the maximum allowed value by the specific hardware.
 
-It is important to highlight that:
-
-!!! warning
-    Programs compiled with the flag `device_max_duration_ratio` are not portable across different devices.
-    The same program compiled on two different devices will be different.
-
-As anticipated, this flag will decouple time from the compilation, letting the user set a time relative to the maximum allowed by the selected device.
-To use it, simply use the corresponding flag at compilation:
+To do so, set the corresponding flag at compilation:
 
 ```python exec="on" source="material-block" html="1" session="drives"
 # Compilation to AnalogDevice max duration
@@ -128,3 +121,12 @@ program.draw(compiled = True)
 fig_compiled = program.draw(compiled = True, return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig_compiled)) # markdown-exec: hide
 ```
+
+As anticipated, this flag will decouple time from the compilation, letting the user set a time relative to the maximum allowed by the selected device.
+Moreover, as a drive's amplitude/detuning can be composed by many waveforms, this feature will simply rescale them preserving their relative durations.
+
+Finally, it is important to highlight that:
+
+!!! warning
+    Programs compiled with the flag `device_max_duration_ratio` are not portable across different devices.
+    The same program compiled on two different devices will be different.

--- a/docs/fundamentals/compilation/device_and_compilation.md
+++ b/docs/fundamentals/compilation/device_and_compilation.md
@@ -123,7 +123,7 @@ print(fig_to_html(fig_compiled)) # markdown-exec: hide
 ```
 
 As anticipated, this flag will decouple time from the compilation, letting the user set a time relative to the maximum allowed by the selected device.
-Moreover, as a drive's amplitude/detuning can be composed by many waveforms, this feature will simply rescale them preserving their relative durations.
+Moreover, as a drive's amplitude/detuning can be composed by many waveforms, this feature will rescale them preserving their relative durations.
 
 Finally, it is important to highlight that:
 

--- a/docs/fundamentals/compilation/device_and_compilation.md
+++ b/docs/fundamentals/compilation/device_and_compilation.md
@@ -104,3 +104,18 @@ program.draw(compiled = True)
 fig_compiled = program.draw(compiled = True, return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig_compiled)) # markdown-exec: hide
 ```
+
+
+## Breaking compilation
+Whenever possible, the compilation step in QoolQit will simply take care of mapping the input quantum program into real hardware instructions.
+In other words, ratios between energies (interactions and drive) and time will be preserved.
+However, in some applications, one may be interested in separating time from the compilation step.
+For example, in adiabatic protocols, one simply seek to extend the duration of a quantum program to the maximum allowed value by the specific hardware.
+
+It is important to highlight that:
+
+!!! warning
+    Programs compiled with the flag `device_max_duration_ratio` are not portable across different devices.
+    The same program compiled on two different devices will be different.
+
+As anticipated, this flag will decouple time from the compilation, letting the user set a time relative to the maximum allowed by the selected device.

--- a/docs/fundamentals/compilation/device_and_compilation.md
+++ b/docs/fundamentals/compilation/device_and_compilation.md
@@ -110,7 +110,7 @@ print(fig_to_html(fig_compiled)) # markdown-exec: hide
 Whenever possible, the compilation step in QoolQit will simply take care of mapping the input quantum program into real hardware instructions.
 In other words, ratios between energies (interactions and drive) and time will be preserved (see [compilation rationale](./rationale.md)).
 However, in some applications, one may be interested in separating time from the compilation step.
-For example, in adiabatic protocols, one simply seek to rescale the duration of a quantum program to the maximum allowed value by the specific hardware.
+For example, in adiabatic protocols, one simply seek to rescale the duration of a quantum program to the maximum value allowed by the specific hardware.
 
 To do so, set the corresponding flag at compilation:
 

--- a/docs/fundamentals/compilation/rationale.md
+++ b/docs/fundamentals/compilation/rationale.md
@@ -88,3 +88,7 @@ resulting amplitude is below $\Omega_{\max}$.
     In both cases, QoolQit selects the largest feasible reference scale $J_0$. Doing so
     gives the fastest possible physical runtime for the program, since $t = \tilde{t}/J_0$
     decreases as $J_0$ increases.
+
+
+### Working point compilation
+In progress...

--- a/docs/fundamentals/quantum_program.md
+++ b/docs/fundamentals/quantum_program.md
@@ -238,7 +238,9 @@ print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
 To understand the role of time and the duration of a drive in the Rydberg Analog model, please have a look at the [Time regimes](../get_started/qoolqit_model.md#time-regimes) page.
-To simply use the maximum available time of a specific hardware device, for example when working on adiabatic protocols, please have a look at the [Device and compilation](../fundamentals/compilation/device_and_compilation.md) page of the documentation, specifically at the [Special compilation flags](../fundamentals/compilation/device_and_compilation.md#special-compilation-maximum-allowed-duration) section.
+Alternatively, duration can also be set at compilation time, as relative to the maximum duration allowed by a specific hardware device.
+Such feature, is useful, for example, when working on adiabatic protocols.
+For more details, please have a look at the [Device and compilation](../fundamentals/compilation/device_and_compilation.md) page of the documentation, specifically at the [Special compilation flags](../fundamentals/compilation/device_and_compilation.md#special-compilation-maximum-allowed-duration) section.
 
 ## Defining a quantum program
 

--- a/docs/fundamentals/quantum_program.md
+++ b/docs/fundamentals/quantum_program.md
@@ -204,7 +204,7 @@ examples and how to use custom waveforms inside a `Drive` — see
 
 ## Drives
 
-The `Drive` is a collection of amplitude and detuning waveforms, plus and optional phase, fully specifying the drive Hamiltonian, as described in the [QoolQit model](../get_started/qoolqit_model.md#qoolqit-model) page.
+The `Drive` is a collection of amplitude and detuning waveforms, plus an optional phase, fully specifying the drive Hamiltonian, as described in the [QoolQit model](../get_started/qoolqit_model.md#qoolqit-model) page.
 Here is an example on how to create a drive:
 
 ```python exec="on" source="material-block" result="json" session="drives"

--- a/docs/fundamentals/quantum_program.md
+++ b/docs/fundamentals/quantum_program.md
@@ -238,6 +238,7 @@ print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
 To understand the role of time and the duration of a drive in the Rydberg Analog model, please have a look at the [Time regimes](../get_started/qoolqit_model.md#time-regimes) page.
+To simply use the maximum available time of a specific hardware device, for example when working on adiabatic protocols, please have a look at the [Device and compilation](../fundamentals/compilation/device_and_compilation.md) page of the documentation, specifically at the [Special compilation flags](../fundamentals/compilation/device_and_compilation.md#special-compilation-maximum-allowed-duration) section.
 
 ## Defining a quantum program
 

--- a/docs/fundamentals/quantum_program.md
+++ b/docs/fundamentals/quantum_program.md
@@ -238,7 +238,7 @@ print(fig_to_html(fig)) # markdown-exec: hide
 ```
 
 To understand the role of time and the duration of a drive in the Rydberg Analog model, please have a look at the [Time regimes](../get_started/qoolqit_model.md#time-regimes) page.
-Alternatively, duration can also be set at compilation time, as relative to the maximum duration allowed by a specific hardware device.
+Alternatively, duration can also be overwritten at compilation time, as relative to the maximum duration allowed by a specific hardware device.
 Such feature, is useful, for example, when working on adiabatic protocols.
 For more details, please have a look at the [Device and compilation](../fundamentals/compilation/device_and_compilation.md) page of the documentation, specifically at the [Special compilation flags](../fundamentals/compilation/device_and_compilation.md#special-compilation-maximum-allowed-duration) section.
 

--- a/docs/fundamentals/quantum_program.md
+++ b/docs/fundamentals/quantum_program.md
@@ -204,28 +204,30 @@ examples and how to use custom waveforms inside a `Drive` — see
 
 ## Drives
 
-
-The `Drive` is a composition of waveforms defining the drive Hamiltonian.
+The `Drive` is a collection of amplitude and detuning waveforms, plus and optional phase, fully specifying the drive Hamiltonian, as described in the [QoolQit model](../get_started/qoolqit_model.md#qoolqit-model) page.
+Here is an example on how to create a drive:
 
 ```python exec="on" source="material-block" result="json" session="drives"
 from qoolqit import Constant, Ramp
 from qoolqit import Drive
 
 # Defining two waveforms
-wf0 = Constant(0.5, 1.0) >> Ramp(1.0, 0.0, 0.5)
-wf1 = Ramp(2.0, -1.0, 1.0) >> Constant(1.0, 1.0)
+amplitude = Constant(5.0, 1.0) >> Ramp(1.0, 0.0, 0.5)
+detuning = Ramp(2.0, -1.0, 1.0) >> Constant(1.0, 1.0)
 
 # Defining the drive
 drive = Drive(
-    amplitude = wf0,
-    detuning = wf1
+    amplitude = amplitude,
+    detuning = detuning
 )
 
 # Expanding the drive through composition
 drive = drive >> drive
-
 print(drive)  # markdown-exec: hide
 ```
+
+While defining an amplitude is required, if not provided, the detuning and the phase value will be assumed to be zero.
+Finally, after creation, drives can be conveniently plotted and inspected as:
 
 ```python exec="on" source="material-block" html="1" session="drives"
 import matplotlib.pyplot as plt # markdown-exec: hide
@@ -234,6 +236,8 @@ drive.draw()
 fig = drive.draw(return_fig = True) # markdown-exec: hide
 print(fig_to_html(fig)) # markdown-exec: hide
 ```
+
+To understand the role of time and the duration of a drive in the Rydberg Analog model, please have a look at the [Time regimes](../get_started/qoolqit_model.md#time-regimes) page.
 
 ## Defining a quantum program
 

--- a/docs/get_started/qoolqit_model.md
+++ b/docs/get_started/qoolqit_model.md
@@ -1,14 +1,12 @@
-# Introduction
-
 ## Qoolqit model
 
 In neutral-atom systems, atoms interact through a combination of **distance-dependent interactions** and **laser-driven controls**. The interaction strength between two atoms decreases rapidly with their separation $r$ (as $1/r^6$), while the laser beams determine how strongly each atom is driven.
 
 As a result, the behavior of the system is not set by absolute values alone, but by the **interplay between geometry (distances) and control strength (laser power)**. Different combinations of these quantities can lead to equivalent physical behavior, as long as their relative scales are preserved.
 
-!!! QoolQit introduces a **dimensionless reference frame** where all quantities are expressed in function of an **interaction reference**.
+!!! note "QoolQit introduces a **dimensionless reference frame** where all quantities are expressed in function of an **interaction reference**."
 
-The quantum system is described by the following Hamiltonian:
+The quantum system is thus described by the sum of two energetic contribution, the interaction and the driving one, as described by the following Hamiltonian:
 
 $$
 \tilde{H}(t) =
@@ -38,7 +36,7 @@ $$
 
 This means that programs are **hardware-independent until compilation**: drive strengths are naturally expressed as multiples of the interaction strength, and the same program can be compiled to different devices without modification.
 
-!!! The actual physical scale — such as the precise distances or laser amplitudes — is determined only later, during the **compilation step**, when targeting a specific device.
+!!! note "The actual physical scale — such as the precise distances or laser amplitudes — is determined only later, during the **compilation step**, when targeting a specific device."
 
 More details about the connection to physical units are provided in the section [Adimensionalization](../extended_usage/adimensionalization.md).
 
@@ -96,7 +94,6 @@ A convenient way to understand this is to first work entirely in dimensionless u
 This means that compilation does **not** change the dimensionless physics of the program. Instead, it rescales the program so that it lies inside the region that can be implemented on a given device.
 
 ### Example
-
 
 Consider a program defined by $(\tilde{J},\max_{\tilde{t}}\tilde{\Omega}) = (1,0.4),$ so that $\frac{\max_{\tilde{t}}\tilde{\Omega}}{\tilde{J}} = 0.4$.
 


### PR DESCRIPTION
Resolves #241 

> Add documentation to cover the use of:
> ```python
> program.compile_to(..., device_max_duration_ratio=0.5)
> ```
> Entry points for the feature in the docs:
> - When choosing time in the drive section
> - In the compilation pages

