### PR TITLE
bump and remove hatch configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,18 +9,18 @@ repos:
 
 # Reformat source code.
 -   repo: https://github.com/ambv/black
-    rev: 26.1.0
+    rev: 26.3.1
     hooks:
       - id: black
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.15.0"
+    rev: "v0.15.9"
     hooks:
       - id: ruff
         args: [--fix]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.0
     hooks:
       - id: mypy
         exclude: examples|docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "qoolqit"
 description = "A Python library for developing algorithms in the Rydberg Analog Model."
 readme = "README.md"
-version = "0.4.0"
+version = "1.0.0"
 requires-python = ">=3.10"
 license = { text = "MIT-derived" }
 keywords = ["quantum"]
@@ -71,16 +71,8 @@ Documentation = "https://pasqal-io.github.io/qoolqit/latest"
 Issues = "https://github.com/pasqal-io/qoolqit/issues"
 Source = "https://github.com/pasqal-io/qoolqit"
 
-[tool.hatch.metadata]
-allow-direct-references = true
-allow-ambiguous-features = true
-
 [tool.hatch.envs.default]
 features = ["dev"]
-
-[tool.hatch.envs.default.scripts]
-test = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=qoolqit --markdown-docs {args}"
-test_tutorials = "pytest --nbmake docs/tutorials"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -91,28 +83,6 @@ filterwarnings = [
   "ignore:`torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`:DeprecationWarning",
   "ignore:`torch.jit.script` is not supported in Python 3.14:DeprecationWarning",
 ]
-
-[tool.hatch.envs.docs]
-features = ["dev"]
-
-[tool.hatch.envs.docs.scripts]
-build = "mkdocs build --clean --strict"
-serve = "mkdocs serve --dev-addr localhost:8000"
-
-[[tool.hatch.envs.test.matrix]]
-python = ["310", "311", "312", "313"]
-
-[tool.hatch.build.targets.sdist]
-exclude = [
-    "/.gitignore",
-    "/.pre-commit-config.yml",
-    "/tests",
-    "/docs",
-    "/examples",
-]
-
-[tool.hatch.build.targets.wheel]
-packages = ["qoolqit"]
 
 [tool.coverage.run]
 branch = true

--- a/qoolqit/__init__.py
+++ b/qoolqit/__init__.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import pulser
-from packaging.version import Version
+from pulser.sequence import store_package_version_metadata
 
 from qoolqit.devices import (
     AnalogDevice,
@@ -40,11 +39,6 @@ __all__ = [
 ]
 
 
-__version__ = "0.4.0"
+__version__ = "1.0.0"
 
-# metadata are stored only from pulser 1.6.3
-pulser_version = Version(pulser.__version__)
-if pulser_version >= Version("1.6.3"):
-    from pulser.sequence import store_package_version_metadata
-
-    store_package_version_metadata("qoolqit", __version__)
+store_package_version_metadata("qoolqit", __version__)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,24 +2,19 @@ from __future__ import annotations
 
 import json
 
-from packaging.version import Version
-from pulser import __version__ as pulser_version
-
 from qoolqit import Constant, Drive, MockDevice, QuantumProgram, Register
 from qoolqit import __version__ as qoolqit_version
 
 
 def test_compiled_sequence_metadata() -> None:
-    # metadata are stored only from pulser 1.6.3
-    if Version(pulser_version) >= Version("1.6.3"):
-        register = Register({"q0": (0.0, 0.0), "q1": (1.0, 0.0)})
-        drive = Drive(amplitude=Constant(10.0, 1.0))
-        program = QuantumProgram(register, drive)
+    register = Register({"q0": (0.0, 0.0), "q1": (1.0, 0.0)})
+    drive = Drive(amplitude=Constant(10.0, 1.0))
+    program = QuantumProgram(register, drive)
 
-        # check if the metadata is correctly stored in the compiled sequence
-        program.compile_to(MockDevice())
-        compiled_seq_repr = json.loads(program.compiled_sequence.to_abstract_repr())
+    # check if the metadata is correctly stored in the compiled sequence
+    program.compile_to(MockDevice())
+    compiled_seq_repr = json.loads(program.compiled_sequence.to_abstract_repr())
 
-        compiled_seq_metadata = compiled_seq_repr["metadata"]
-        expected_metadata = {"package_versions": {"qoolqit": qoolqit_version}, "extra": {}}
-        assert compiled_seq_metadata == expected_metadata
+    compiled_seq_metadata = compiled_seq_repr["metadata"]
+    expected_metadata = {"package_versions": {"qoolqit": qoolqit_version}, "extra": {}}
+    assert compiled_seq_metadata == expected_metadata


### PR DESCRIPTION
Resolves #246 

## Changes
- bump to v1.0.0 before release
- remove hatch configs in `pyproject.toml` (but let's keep only one that set the default env to dev, in case some people still using it)