### PR TITLE
add failing tests that should pass

### DIFF
--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -93,7 +93,7 @@ def basic_compilation(
     """
     if profile == CompilerProfile.WORKING_POINT:
         TIME, ENERGY, DISTANCE = device.converter.factors
-        _validate_program_default_profile(register, drive, device)
+        _validate_program_default_profile(register, drive, device, device_max_duration_ratio)
     elif profile == CompilerProfile.MAX_ENERGY:
         # fix compilation strategy according to the program energy ratio Ω_max/J_max
         program_energy_ratio = drive.amplitude.max() * register.min_distance() ** 6
@@ -106,7 +106,7 @@ def basic_compilation(
             # map to the minimum pairwise distance allowed on the device
             DISTANCE = device._target_dist / register.min_distance()
             TIME, ENERGY, DISTANCE = device.converter.factors_from_distance(DISTANCE)
-        _validate_program_max_energy_profile(register, drive, device)
+        _validate_program_max_energy_profile(register, drive, device, device_max_duration_ratio)
     else:
         raise ValueError(f"Invalid CompilerProfile: {profile}")
 
@@ -186,6 +186,7 @@ def _validate_program_default_profile(
     register: Register,
     drive: Drive,
     device: Device,
+    device_max_duration_ratio: float | None,
 ) -> None:
     """Validate that the program respect the device specs.
 
@@ -216,13 +217,16 @@ def _validate_program_default_profile(
         )
         raise CompilationError(msg + f"{device}")
 
-    duration = drive.duration
-    if specs["max_duration"] and (duration > specs["max_duration"]):
-        msg = (
-            f"The drive's duration {duration:.4f} "
-            "goes over the maximum value allowed for the chosen device:\n"
-        )
-        raise CompilationError(msg + f"{device}")
+    # only check drive if device has a maximum duration
+    # and it is not manually set with device_max_duration_ratio
+    if specs["max_duration"] and (device_max_duration_ratio is None):
+        duration = drive.duration
+        if duration > specs["max_duration"]:
+            msg = (
+                f"The drive's duration {duration:.4f} "
+                "goes over the maximum value allowed for the chosen device:\n"
+            )
+            raise CompilationError(msg + f"{device}")
 
     if register.n_qubits > 1:
         min_distance = register.min_distance()
@@ -246,6 +250,7 @@ def _validate_program_max_energy_profile(
     register: Register,
     drive: Drive,
     device: Device,
+    device_max_duration_ratio: float | None,
 ) -> None:
     """Validate that the program respect the given device specifications.
 
@@ -303,8 +308,10 @@ def _validate_program_max_energy_profile(
             )
             raise CompilationError(msg_init + msg)
 
-    duration = drive.duration
-    if specs["max_duration"]:
+    # only check drive if device has a maximum duration
+    # and it is not manually set with device_max_duration_ratio
+    if specs["max_duration"] and (device_max_duration_ratio is None):
+        duration = drive.duration
         max_duration_to_compile = specs["max_duration"] / TIME
         if duration > max_duration_to_compile:
             msg = (

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pytest
 from pulser.sequence import Sequence as PulserSequence
 
-from qoolqit import AnalogDevice, DigitalAnalogDevice, MockDevice
+from qoolqit import AnalogDevice, DataGraph, DigitalAnalogDevice, MockDevice
 from qoolqit.devices import Device
 from qoolqit.drive import Drive
 from qoolqit.exceptions import CompilationError
@@ -63,8 +63,13 @@ def test_compiled_sequence_with_small_delays() -> None:
 
 
 @pytest.mark.parametrize("ratio", [0.33, 0.5, 1.0])
-def test_compile_to_max_duration_ratio(ratio: float) -> None:
-    """Test that the compiled sequence's duration is set to the maximum allowed by the device."""
+def test_compile_to_max_duration_ratio(
+    ratio: float,
+) -> None:
+    """Test that the compiled sequence's duration is set to the ratio.
+
+    of the maximum allowed by the device.
+    """
     register = Register(qubits={"q0": (0.0, 0.0), "q1": (1.0, 0.0)})
     drive = Drive(amplitude=Constant(2.0, 1.0))
     program = QuantumProgram(register=register, drive=drive)
@@ -76,6 +81,16 @@ def test_compile_to_max_duration_ratio(ratio: float) -> None:
     program.compile_to(device=device, device_max_duration_ratio=ratio)
     assert program.is_compiled
     assert program.compiled_sequence.get_duration() == expected_max_duration
+
+
+@pytest.mark.parametrize("duration", [2.0, 33.33, 1000.0])
+def test_compile_to_max_duration(duration: float) -> None:
+    """Test that the compiled sequence's duration is set to the maximum allowed by the device."""
+    reg = Register.from_graph(DataGraph.line(2))
+    amp = Constant(duration=duration, value=1.0)
+    drive = Drive(amplitude=amp)
+    program = QuantumProgram(reg, drive)
+    program.compile_to(AnalogDevice(), device_max_duration_ratio=1.0)
 
 
 def test_max_duration_ratio_error() -> None:

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -63,11 +63,10 @@ def test_compiled_sequence_with_small_delays() -> None:
 
 
 @pytest.mark.parametrize("ratio", [0.33, 0.5, 1.0])
-def test_compile_to_max_duration_ratio(
-    ratio: float,
-) -> None:
-    """Test that the compiled sequence's duration is set to the ratio.
+def test_compile_to_max_duration_ratio(ratio: float) -> None:
+    """Test `device_max_duration_ratio` compilation flag.
 
+    Check that that the compiled sequence's duration is set to the ratio
     of the maximum allowed by the device.
     """
     register = Register(qubits={"q0": (0.0, 0.0), "q1": (1.0, 0.0)})

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -67,7 +67,7 @@ def test_compile_to_max_duration_ratio(ratio: float) -> None:
     """Test `device_max_duration_ratio` compilation flag.
 
     Check that that the compiled sequence's duration is set to the ratio
-    of the maximum allowed by the device.
+    of the maximum duration allowed by the device.
     """
     register = Register(qubits={"q0": (0.0, 0.0), "q1": (1.0, 0.0)})
     drive = Drive(amplitude=Constant(2.0, 1.0))

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -92,6 +92,9 @@ def test_compile_to_max_duration(duration: float) -> None:
     program = QuantumProgram(reg, drive)
     program.compile_to(AnalogDevice(), device_max_duration_ratio=1.0)
 
+    assert program.is_compiled
+    assert program.compiled_sequence.get_duration() == 6000
+
 
 def test_max_duration_ratio_error() -> None:
     """Test that a ValueError is raised when the device_max_duration_ratio is not in (0,1]."""


### PR DESCRIPTION
Resolves #259 

The bug originates in compilation.
The duration of a program is checked before the flag `device_max_duration_ratio` can manipulate the program, thus the compilation error.

## To solve
To solve at the moment produce a bit of code duplication:
- conditional check in `_validate_program_max_energy`
- conditional check in `_validate_program_default`

In both instances the duration check is disabled if
- device does not have a max duration
- `device_max_duration_ratio` is selected

## Changes
- add a failing test. As suggested in #259, set large duration and `device_max_duration_ratio=1.0` together.
- added logic to disable duration check is `device_max_duration_ratio` is selected