### PR TITLE
fix BladeConfig with new blade algo signature

### DIFF
--- a/docs/extended_usage/custom_embedders.md
+++ b/docs/extended_usage/custom_embedders.md
@@ -90,7 +90,7 @@ class MyWrongConfig(EmbedderConfig):
 
 try:
     wrong_embedder = GraphToGraphEmbedder(my_embedding_function, MyWrongConfig())
-except KeyError as error:
+except TypeError as error:
     print(error)
 ```
 

--- a/qoolqit/embedding/algorithms/blade/blade.py
+++ b/qoolqit/embedding/algorithms/blade/blade.py
@@ -588,9 +588,10 @@ class BladeConfig(EmbedderConfig):
     compute_weight_relative_threshold: Callable[[float], float] = lambda _: 0.1
     compute_max_distance_to_walk: Callable[
         [float, float | None], float | tuple[float, float, float]
-    ] = lambda x, max_radial_dist: np.inf
-    starting_ratio_factor: int = 2
-    draw_steps: bool | list[int] = False
+    ] = default_compute_max_distance_to_walk
+    compute_regulation_cursor: Callable[[float], float] = lambda _: 0.1
+    compute_ratio_step_factors: Callable[[float], float] = default_compute_ratio_step_factors
+    ratio_rerun: int = 2
     device: InitVar[Device | None] = None
 
     def __post_init__(self, device: Device | None) -> None:

--- a/qoolqit/embedding/base_embedder.py
+++ b/qoolqit/embedding/base_embedder.py
@@ -45,19 +45,23 @@ class BaseEmbedder(ABC, Generic[InDataType, OutDataType, ConfigType]):
             algorithm: a callable to the algorithm function.
             config: a config dataclass holding parameter values for the algorithm.
         """
-
-        algo_signature = inspect.signature(algorithm)
-
         if not isinstance(config, EmbedderConfig):
             raise TypeError(
                 "The config must be an instance of a dataclass inheriting from EmbedderConfig."
             )
 
-        if not set(config.dict().keys()) <= set(algo_signature.parameters):
-            raise KeyError(
+        algo_signature = inspect.signature(algorithm)
+        config_keys = set(config.dict().keys())
+        algo_signature_keys = set(algo_signature.parameters.keys())
+        if not config_keys <= algo_signature_keys:
+            config_keys_str = "\n".join(f"\t- {key}" for key in config_keys)
+            algo_keys_str = "\n".join(f"\t- {key}" for key in algo_signature_keys)
+            raise TypeError(
                 f"Config {config.__class__.__name__} is not compatible with the "
                 + f"algorithm {algorithm.__name__}, as not all configuration fields "
-                + "correspond to keyword arguments in the algorithm function."
+                + "correspond to keyword arguments in the algorithm function.\n\n"
+                + f"Config {config.__class__.__name__} keys:\n{config_keys_str}\n\n"
+                + f"Algorithm signature parameters:\n{algo_keys_str}"
             )
 
         self._algorithm = algorithm

--- a/tests/test_embedding/blade/test_blade.py
+++ b/tests/test_embedding/blade/test_blade.py
@@ -11,7 +11,7 @@ from pulser.register.special_layouts import TriangularLatticeLayout
 
 from qoolqit import AnalogDevice, DigitalAnalogDevice, MockDevice
 from qoolqit.devices import Device
-from qoolqit.embedding import BladeConfig
+from qoolqit.embedding import Blade, BladeConfig
 from qoolqit.embedding.algorithms.blade._helpers import (
     distance_matrix_from_positions,
     interaction_matrix_from_distances,
@@ -588,3 +588,13 @@ def test_embed_large_dense_register_from_hexagonal_lattice() -> None:
     )
 
     assert ratio <= expected_ratio
+
+
+def test_blade_init() -> None:
+    embedder = Blade()
+    assert embedder.config == BladeConfig()
+
+
+def test_invalid_blade_config() -> None:
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'wrong_config_key'"):
+        BladeConfig(wrong_config_key="value")  # type: ignore

--- a/tests/test_embedding/test_base_embedders.py
+++ b/tests/test_embedding/test_base_embedders.py
@@ -29,7 +29,11 @@ def test_custom_embedders() -> None:
     class WrongParamConfig(EmbedderConfig):  # type: ignore
         param2: float = 1.0
 
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        TypeError,
+        match="Config WrongParamConfig is not compatible with the algorithm some_embedding_algo, "
+        "as not all configuration fields correspond to keyword arguments in the algorithm",
+    ):
         GraphToGraphEmbedder(some_embedding_algo, WrongParamConfig())
 
     # Embedding function returns unexpected data


### PR DESCRIPTION
Resolves #276

> from qoolqit.embedding.matrix_embedder import Blade
> b = Blade()
> 
> raises
> 
> E           KeyError: 'Config BladeConfig is not compatible with the algorithm blade,
> as not all configuration fields correspond to keyword arguments in the algorithm function.'
> `

## Description
Blade signature was recently changed, but the config data class wasn't updated.

## Changes
- update parameters in `BladeConfig` data class
- add a unit test that simply successfully initialize `Blade` with its default config.
- BONUS: better error message if config keys do not match algo signature

