### PR TITLE
refine max radial error in CompilationError

### DIFF
--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -292,8 +292,8 @@ def _validate_program_max_energy_profile(
         if max_radial_distance > max_radial_distance_to_compile:
             msg = (
                 "The register's maximum radial distance went over the maximum value allowed.\n"
-                "To compile your program, set the "
-                f"maximum radial distance below {max_radial_distance_to_compile}"
+                f"To compile this program on the selected device `{device.name}`, "
+                f"the maximum radial distance must be below {max_radial_distance_to_compile}"
             )
             raise CompilationError(msg_init + msg)
 
@@ -303,7 +303,7 @@ def _validate_program_max_energy_profile(
         if max_abs_detuning > max_abs_detuning_to_compile:
             msg = (
                 "The drive's maximum absolute detuning went over the maximum value allowed.\n"
-                "To compile your program, set the "
+                f"To compile this program on the selected device `{device.name}`, set the "
                 f"maximum absolute detuning below {max_abs_detuning_to_compile}"
             )
             raise CompilationError(msg_init + msg)
@@ -316,7 +316,7 @@ def _validate_program_max_energy_profile(
         if duration > max_duration_to_compile:
             msg = (
                 "The drive's duration went over the maximum value allowed.\n"
-                "To compile your program, set the "
+                f"To compile this program on the selected device `{device.name}`, set the "
                 f"drive's duration below {max_duration_to_compile}"
             )
             raise CompilationError(msg_init + msg)

--- a/tests/test_compilation/test_max_energy.py
+++ b/tests/test_compilation/test_max_energy.py
@@ -22,7 +22,7 @@ from qoolqit.exceptions import CompilationError
 from qoolqit.execution.compilation_functions import CompilerProfile
 
 
-class TestWorkingPointCompilerProfile:
+class TestMaxEnergyCompilerProfile:
     profile = CompilerProfile.MAX_ENERGY
 
     @pytest.fixture(autouse=True)
@@ -82,8 +82,10 @@ class TestWorkingPointCompilerProfile:
             max_abs_det_allowed = device.specs["max_abs_detuning"] / ENERGY
             with pytest.raises(
                 CompilationError,
-                match="To compile your program, set the maximum absolute"
-                f" detuning below {max_abs_det_allowed}",
+                match=(
+                    f"To compile this program on the selected device `{device.name}`, "
+                    f"set the maximum absolute detuning below {max_abs_det_allowed}"
+                ),
             ):
                 program.compile_to(AnalogDevice(), profile=self.profile)
 
@@ -99,7 +101,10 @@ class TestWorkingPointCompilerProfile:
         ENERGY = device._target_amp_adim / amplitude.max()
         if device.specs["max_duration"]:
             max_duration_allowed = device.specs["max_duration"] * ENERGY
-            msg = f"To compile your program, set the drive's duration below {max_duration_allowed}"
+            msg = (
+                f"To compile this program on the selected device `{device.name}`, "
+                f"set the drive's duration below {max_duration_allowed}"
+            )
             with pytest.raises(CompilationError, match=msg):
                 program.compile_to(AnalogDevice(), profile=self.profile)
 
@@ -114,8 +119,8 @@ class TestWorkingPointCompilerProfile:
         if device.specs["max_radial_distance"]:
             max_radial_distance_allowed = device.specs["max_radial_distance"] * ENERGY ** (1 / 6)
             msg = (
-                "To compile your program, set the maximum radial"
-                f" distance below {max_radial_distance_allowed}"
+                f"To compile this program on the selected device `{device.name}`, "
+                f"the maximum radial distance must be below {max_radial_distance_allowed}"
             )
             with pytest.raises(CompilationError, match=msg):
                 program.compile_to(AnalogDevice(), profile=self.profile)


### PR DESCRIPTION
Resolves #275 

> Do not say `set` in the error since it cannot be really set straightforwardly.
> Say instead that a register has to comply with some spec.

## Changes
The error for max_radial is now:

> To compile this program on the selected device `{device.name}`, the maximum radial distance must be below {max_radial_distance_to_compile}"