### PR TITLE
fix compilation error on interpolated waveform

### DIFF
--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -60,10 +60,11 @@ class WaveformConverter:
         """Convert a QoolQit waveform into a equivalent Pulser waveform."""
         pulser_duration = self._pulser_duration(waveform)
 
+        # see https://github.com/pasqal-io/qoolqit/issues/288
+        # pulser.InterpolatedWaveform round values to 1e8 which can lead to amplitudes
+        # higher than what the device allows.
+        # Once solved in pulser the additional rounding below can be removed.
         if isinstance(waveform, Interpolated):
-            # fix https://github.com/pasqal-io/qoolqit/issues/288
-            # pulser.InterpolatedWaveform round values to 1e8 which
-            # can lead to higher amplitudes that what the device allows.
             self._energy = math.floor(self._energy * 1e8) / 1e8
 
         return waveform._to_pulser(duration=pulser_duration) * self._energy

--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from enum import Enum
 
 from pulser.devices import Device as PulserDevice
@@ -13,6 +14,7 @@ from qoolqit.devices import Device
 from qoolqit.drive import Drive, Waveform, WeightedDetuning
 from qoolqit.exceptions import CompilationError
 from qoolqit.register import Register
+from qoolqit.waveforms import Interpolated
 
 
 class CompilerProfile(Enum):
@@ -57,6 +59,13 @@ class WaveformConverter:
     def convert(self, waveform: Waveform) -> ParamObj | PulserWaveform:
         """Convert a QoolQit waveform into a equivalent Pulser waveform."""
         pulser_duration = self._pulser_duration(waveform)
+
+        if isinstance(waveform, Interpolated):
+            # fix https://github.com/pasqal-io/qoolqit/issues/288
+            # pulser.InterpolatedWaveform round values to 1e8 which
+            # can lead to higher amplitudes that what the device allows.
+            self._energy = math.floor(self._energy * 1e8) / 1e8
+
         return waveform._to_pulser(duration=pulser_duration) * self._energy
 
 

--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -64,6 +64,7 @@ class WaveformConverter:
         # pulser.InterpolatedWaveform round values to 1e8 which can lead to amplitudes
         # higher than what the device allows.
         # Once solved in pulser the additional rounding below can be removed.
+        # see https://github.com/pasqal-io/Pulser/issues/1051
         if isinstance(waveform, Interpolated):
             self._energy = math.floor(self._energy * 1e8) / 1e8
 

--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from enum import Enum
 
 from pulser.devices import Device as PulserDevice
@@ -60,13 +59,12 @@ class WaveformConverter:
         """Convert a QoolQit waveform into a equivalent Pulser waveform."""
         pulser_duration = self._pulser_duration(waveform)
 
+        # Interpolated to be converted differently because of round off issue:
         # see https://github.com/pasqal-io/qoolqit/issues/288
-        # pulser.InterpolatedWaveform round values to 1e8 which can lead to amplitudes
-        # higher than what the device allows.
-        # Once solved in pulser the additional rounding below can be removed.
         # see https://github.com/pasqal-io/Pulser/issues/1051
         if isinstance(waveform, Interpolated):
-            self._energy = math.floor(self._energy * 1e8) / 1e8
+            wf = waveform._to_pulser(duration=pulser_duration, energy_factor=self._energy)
+            return wf
 
         return waveform._to_pulser(duration=pulser_duration) * self._energy
 

--- a/qoolqit/waveforms/waveforms.py
+++ b/qoolqit/waveforms/waveforms.py
@@ -243,7 +243,7 @@ class Interpolated(Waveform):
         # to avoid overflow when converting to pulser waveforms.
         # see: https://github.com/pasqal-io/qoolqit/issues/288
         # see: https://github.com/pasqal-io/Pulser/issues/1051
-        truncated_values = np.floor(self._values * energy_factor * 1e8) / 1e8
+        truncated_values = np.trunc(self._values * energy_factor * 1e8) / 1e8
         return pulser.InterpolatedWaveform(
             duration,
             values=truncated_values,

--- a/qoolqit/waveforms/waveforms.py
+++ b/qoolqit/waveforms/waveforms.py
@@ -234,10 +234,19 @@ class Interpolated(Waveform):
     def max(self) -> float:
         return float(self._values.max())
 
-    def _to_pulser(self, duration: int) -> ParamObj | pulser.InterpolatedWaveform:
+    def _to_pulser(
+        self,
+        duration: int,
+        energy_factor: float = 1.0,
+    ) -> ParamObj | pulser.InterpolatedWaveform:
+        # Truncate the values to the specified energy factor,
+        # to avoid overflow when converting to pulser waveforms.
+        # see: https://github.com/pasqal-io/qoolqit/issues/288
+        # see: https://github.com/pasqal-io/Pulser/issues/1051
+        truncated_values = np.floor(self._values * energy_factor * 1e8) / 1e8
         return pulser.InterpolatedWaveform(
             duration,
-            values=self._values,
+            values=truncated_values,
             times=self._times,
             interpolator=self._interpolator,
             **self._interpolator_kwargs,

--- a/tests/test_compilation/test_max_energy.py
+++ b/tests/test_compilation/test_max_energy.py
@@ -6,6 +6,7 @@ from typing import Callable
 
 import numpy as np
 import pytest
+from pulser.sampler import sample
 from pulser.sequence import Sequence as PulserSequence
 
 from qoolqit import (
@@ -14,6 +15,7 @@ from qoolqit import (
     Device,
     DigitalAnalogDevice,
     Drive,
+    Interpolated,
     MockDevice,
     QuantumProgram,
     Register,
@@ -124,3 +126,20 @@ class TestMaxEnergyCompilerProfile:
             )
             with pytest.raises(CompilationError, match=msg):
                 program.compile_to(AnalogDevice(), profile=self.profile)
+
+    @pytest.mark.parametrize("device", [AnalogDevice(), DigitalAnalogDevice(), MockDevice()])
+    def test_compilation_interpolated(self, device: Device) -> None:
+        register = Register.from_coordinates([[0, 0], [0, 1]])
+        amp_wave = Interpolated(60.0, [0.0, 0.5, 1.0, 0.5, 0.0])
+        drive = Drive(amplitude=amp_wave)
+        program = QuantumProgram(register=register, drive=drive)
+        program.compile_to(device=device, profile=self.profile)
+
+        # check this program is compiled to ~ device max amplitude
+        if device._max_amp is not None:
+            # extract sequence max amplitude
+            seq_sample = sample(program.compiled_sequence)
+            seq_max_amp = max(seq_sample.channel_samples["rydberg"].amp)
+
+            np.testing.assert_allclose(seq_max_amp, device._max_amp, atol=1e-8)
+            assert seq_max_amp < device._max_amp

--- a/tests/test_compilation/test_max_energy.py
+++ b/tests/test_compilation/test_max_energy.py
@@ -6,6 +6,7 @@ from typing import Callable
 
 import numpy as np
 import pytest
+from numpy.typing import ArrayLike
 from pulser.sampler import sample
 from pulser.sequence import Sequence as PulserSequence
 
@@ -128,9 +129,17 @@ class TestMaxEnergyCompilerProfile:
                 program.compile_to(AnalogDevice(), profile=self.profile)
 
     @pytest.mark.parametrize("device", [AnalogDevice(), DigitalAnalogDevice(), MockDevice()])
-    def test_compilation_interpolated(self, device: Device) -> None:
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [0.0, 0.5, 1.0, 0.5, 0.0],
+            np.sin(np.linspace(0, 2 * np.pi, 10)) ** 2,
+            [0.7504049424354939, 0.1, 0.1, 0.0],
+        ],
+    )
+    def test_compilation_interpolated(self, device: Device, values: ArrayLike) -> None:
         register = Register.from_coordinates([[0, 0], [0, 1]])
-        amp_wave = Interpolated(60.0, [0.0, 0.5, 1.0, 0.5, 0.0])
+        amp_wave = Interpolated(duration=60.0, values=values)
         drive = Drive(amplitude=amp_wave)
         program = QuantumProgram(register=register, drive=drive)
         program.compile_to(device=device, profile=self.profile)

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -5,6 +5,7 @@ import random
 import numpy as np
 import pulser
 import pytest
+from numpy.typing import ArrayLike
 from scipy.integrate import quad
 
 from qoolqit import Blackman
@@ -194,7 +195,29 @@ def test_interpolated_to_pulser() -> None:
     interpolated = Interpolated(20.46, values=values)
 
     pulser_interpolated = interpolated._to_pulser(duration=222)
+    assert isinstance(pulser_interpolated, pulser.InterpolatedWaveform)
     assert pulser_interpolated.duration == 222
+
+
+@pytest.mark.parametrize(
+    "values", [[0.1, 0.3, -0.5, 1.0, 5.7], np.sin(np.linspace(0, 2 * np.pi, 10))]
+)
+@pytest.mark.parametrize("energy_factor", [0.5, 1.0, np.pi])
+def test_interpolated_to_pulser_energy_factor(values: ArrayLike, energy_factor: float) -> None:
+    interpolated = Interpolated(20.46, values=values)
+
+    pulser_interpolated = interpolated._to_pulser(duration=20, energy_factor=energy_factor)
+    assert isinstance(pulser_interpolated, pulser.InterpolatedWaveform)
+
+    # check that pulser values are scaled correctly, within the expected tolerance
+    expected_pulser_values = np.array(values) * energy_factor
+    np.testing.assert_allclose(pulser_interpolated._values, expected_pulser_values, atol=1e-8)
+
+    # check that pulser samples are within the expected range
+    min_value, max_value = expected_pulser_values.min(), expected_pulser_values.max()
+    pulser_interpolated_samples = pulser_interpolated.samples
+    assert np.all(pulser_interpolated_samples >= min_value)
+    assert np.all(pulser_interpolated_samples <= max_value)
 
 
 @pytest.mark.parametrize("n_waveforms", [3, 4, 5])


### PR DESCRIPTION
Resolves #288 

## Changes
- unit test
- temporary fix: for interpolated waveforms, when translating the Interpolated waveform to the pulser equivalent, preemptively truncate values.