### PR TITLE
add dmm

### DIFF
--- a/qoolqit/drive.py
+++ b/qoolqit/drive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
-from logging import warning
 from typing import Any, Sequence
 
 import matplotlib.pyplot as plt
@@ -131,7 +131,7 @@ class Drive:
 
         self._weighted_detunings = weighted_detunings
         if self._weighted_detunings is not None:
-            warning(
+            warnings.warn(
                 "Warning: `weighted_detunings` in Drive is deprecated. "
                 "Use `dmm` instead. This will be removed in a future version."
             )
@@ -182,10 +182,10 @@ class Drive:
         else:
             raise NotImplementedError(f"Composing with object of type {type(other)} not supported.")
 
-    def __amp_header__(self) -> str:  # pragma: no cover
+    def __amp_header__(self) -> str:
         return "Amplitude: \n"
 
-    def __det_header__(self) -> str:  # pragma: no cover
+    def __det_header__(self) -> str:
         return "Detuning: \n"
 
     def __repr__(self) -> str:

--- a/qoolqit/drive.py
+++ b/qoolqit/drive.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -10,12 +9,12 @@ from matplotlib.figure import Figure
 
 from qoolqit.waveforms import CompositeWaveform, Delay, Waveform
 
-__all__ = ["WeightedDetuning", "DetuningMapModulator", "Drive"]
+__all__ = ["DetuningMapModulator", "Drive"]
 
 
 @dataclass(frozen=True)
 class DetuningMapModulator:
-    """A weighted detuning for the Detuning Map Modulation (DMM).
+    """A weighted detuning for the Detuning Map Modulator (DMM).
 
     Args:
         waveform: The waveform for this detuning. Must be negative for all times.
@@ -36,9 +35,6 @@ class DetuningMapModulator:
             raise ValueError("`weights` must be a dictionary of values in [0, 1].")
 
 
-WeightedDetuning = DetuningMapModulator
-
-
 class Drive:
     """The drive Hamiltonian acting over a duration."""
 
@@ -47,7 +43,6 @@ class Drive:
         *,
         amplitude: Waveform,
         detuning: Waveform | None = None,
-        weighted_detunings: list[WeightedDetuning] | None = None,
         dmm: DetuningMapModulator | None = None,
         phase: float = 0.0,
     ) -> None:
@@ -64,8 +59,6 @@ class Drive:
         - Detuning δ(t): Controls the energy offset of the Rydberg state.
         - dmm εᵢ, Δ(t): Detuning Map Modulator (DMM) for additional qubit-specific detunings.
         - Phase φ: Global phase applied to the amplitude term.
-        - Weighted detunings: [DEPRECATED] Individual qubit detunings via
-            Detuning Map Modulation (DMM).
 
         Args:
             amplitude: Time-dependent amplitude waveform Ω(t) representing the Rabi frequency.
@@ -78,10 +71,6 @@ class Drive:
                 applied to individual qubits as specified by its `weights` attribute εᵢ.
             phase: Global phase φ applied to the amplitude term in the Hamiltonian.
                 Defaults to 0.0 (no phase).
-            weighted_detunings: [DEPRECATED] List of additional detuning waveforms applied to
-                individual qubits using Detuning Map Modulation (DMM). Each WeightedDetuning
-                specifies weights εᵢ for different qubits and a corresponding waveform Δ(t).
-                Note that DMM is not supported on all devices.
 
         Raises:
             TypeError: If amplitude or detuning are not Waveform instances.
@@ -129,21 +118,10 @@ class Drive:
             self._amplitude = CompositeWaveform(self._amplitude, Delay(extra_duration))
 
         self._duration = self._amplitude.duration
-        self._phase = phase
-
-        if weighted_detunings is not None:
-            warnings.warn(
-                "Warning: `weighted_detunings` in Drive is deprecated. "
-                "Use `dmm` instead. This will be removed in a future version."
-            )
-            if dmm is not None:
-                raise ValueError(
-                    "Cannot specify both `weighted_detunings` and `dmm`. "
-                    "`weighted_detunings` is deprecated, use `dmm` instead."
-                )
-        self._weighted_detunings = weighted_detunings
-
+        if dmm is not None and not isinstance(dmm, DetuningMapModulator):
+            raise TypeError("'dmm' must be of type DetuningMapModulator.")
         self._dmm = dmm
+        self._phase = phase
 
     @property
     def amplitude(self) -> Waveform:
@@ -154,11 +132,6 @@ class Drive:
     def detuning(self) -> Waveform:
         """The detuning waveform in the drive."""
         return self._detuning_orig
-
-    @property
-    def weighted_detunings(self) -> Sequence[WeightedDetuning] | None:
-        """Detunings applied to individual qubits."""
-        return self._weighted_detunings
 
     @property
     def dmm(self) -> DetuningMapModulator | None:

--- a/qoolqit/drive.py
+++ b/qoolqit/drive.py
@@ -62,8 +62,10 @@ class Drive:
         representing:
         - Amplitude Ω(t): Controls the Rabi frequency that drives qubits.
         - Detuning δ(t): Controls the energy offset of the Rydberg state.
+        - dmm εᵢ, Δ(t): Detuning Map Modulator (DMM) for additional qubit-specific detunings.
         - Phase φ: Global phase applied to the amplitude term.
-        - Weighted detunings: Individual qubit detunings via Detuning Map Modulation (DMM).
+        - Weighted detunings: [DEPRECATED] Individual qubit detunings via
+            Detuning Map Modulation (DMM).
 
         Args:
             amplitude: Time-dependent amplitude waveform Ω(t) representing the Rabi frequency.
@@ -72,12 +74,14 @@ class Drive:
             detuning: Time-dependent detuning waveform δ(t) representing the energy offset
                 of the Rydberg state relative to resonance. If None, defaults to zero
                 detuning (Delay waveform) for the duration of the amplitude.
+            dmm: DetuningMapModulator instance for additional negative detuning waveform Δ(t) ≤ 0
+                applied to individual qubits as specified by its `weights` attribute εᵢ.
             phase: Global phase φ applied to the amplitude term in the Hamiltonian.
                 Defaults to 0.0 (no phase).
-            weighted_detunings: List of additional detuning waveforms applied to individual
-                qubits using Detuning Map Modulation (DMM). Each WeightedDetuning specifies
-                weights εᵢ for different qubits and a corresponding waveform Δ(t). Note that DMM
-                is not supported on all devices. Defaults to an empty list.
+            weighted_detunings: [DEPRECATED] List of additional detuning waveforms applied to
+                individual qubits using Detuning Map Modulation (DMM). Each WeightedDetuning
+                specifies weights εᵢ for different qubits and a corresponding waveform Δ(t).
+                Note that DMM is not supported on all devices.
 
         Raises:
             TypeError: If amplitude or detuning are not Waveform instances.
@@ -89,8 +93,8 @@ class Drive:
               automatically extended with a Delay to match the longer duration.
             - The resulting Drive duration equals the maximum of the amplitude and
               detuning durations.
-            - WeightedDetuning waveforms must be non-positive (≤ 0) as they represent
-              energy shifts below the resonance.
+            - DetuningMapModulator waveform must be negative for all times
+                (≤ 0) as it represents energy shifts below the resonance.
 
         Example:
             >>> from qoolqit import Drive
@@ -129,12 +133,12 @@ class Drive:
         self._duration = self._amplitude.duration
         self._phase = phase
 
-        self._weighted_detunings = weighted_detunings
-        if self._weighted_detunings is not None:
+        if weighted_detunings is not None:
             warnings.warn(
                 "Warning: `weighted_detunings` in Drive is deprecated. "
                 "Use `dmm` instead. This will be removed in a future version."
             )
+        self._weighted_detunings = weighted_detunings
 
         self._dmm = dmm
 

--- a/qoolqit/drive.py
+++ b/qoolqit/drive.py
@@ -91,8 +91,6 @@ class Drive:
             - All arguments must be passed as keyword arguments.
             - If amplitude and detuning have different durations, the shorter one is
               automatically extended with a Delay to match the longer duration.
-            - The resulting Drive duration equals the maximum of the amplitude and
-              detuning durations.
             - DetuningMapModulator waveform must be negative for all times
                 (≤ 0) as it represents energy shifts below the resonance.
 

--- a/qoolqit/drive.py
+++ b/qoolqit/drive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from logging import warning
 from typing import Any, Sequence
 
 import matplotlib.pyplot as plt
@@ -9,28 +10,33 @@ from matplotlib.figure import Figure
 
 from qoolqit.waveforms import CompositeWaveform, Delay, Waveform
 
-__all__ = ["WeightedDetuning", "Drive"]
+__all__ = ["WeightedDetuning", "DetuningMapModulator", "Drive"]
 
 
-@dataclass
-class WeightedDetuning:
+@dataclass(frozen=True)
+class DetuningMapModulator:
     """A weighted detuning for the Detuning Map Modulation (DMM).
 
     Args:
+        waveform: The waveform for this detuning. Must be negative for all times.
         weights: A dictionary associating detuning weights to qubits.
             Each weight must be in [0, 1], where 0 means that the waveform is ignored for
             this qubit and 1 means that the waveform is fully applied to this qubit.
-        waveform: The waveform for this detuning. Must be negative for all times.
 
     See https://docs.pasqal.com/pulser/tutorials/dmm/ for details on DMM.
     """
 
-    weights: dict[Any, float]
     waveform: Waveform
+    weights: dict[Any, float]
 
     def __post_init__(self) -> None:
         if self.waveform.max() > 0:
-            raise ValueError("WeightedDetuning waveform must be negative.")
+            raise ValueError("`waveform` must be negative for all times.")
+        if any(weight < 0 or weight > 1 for weight in self.weights.values()):
+            raise ValueError("`weights` must be a dictionary of values in [0, 1].")
+
+
+WeightedDetuning = DetuningMapModulator
 
 
 class Drive:
@@ -42,6 +48,7 @@ class Drive:
         amplitude: Waveform,
         detuning: Waveform | None = None,
         weighted_detunings: list[WeightedDetuning] | None = None,
+        dmm: DetuningMapModulator | None = None,
         phase: float = 0.0,
     ) -> None:
         """Initialize a Drive.
@@ -121,7 +128,15 @@ class Drive:
 
         self._duration = self._amplitude.duration
         self._phase = phase
-        self._weighted_detunings = weighted_detunings if weighted_detunings is not None else []
+
+        self._weighted_detunings = weighted_detunings
+        if self._weighted_detunings is not None:
+            warning(
+                "Warning: `weighted_detunings` in Drive is deprecated. "
+                "Use `dmm` instead. This will be removed in a future version."
+            )
+
+        self._dmm = dmm
 
     @property
     def amplitude(self) -> Waveform:
@@ -134,9 +149,14 @@ class Drive:
         return self._detuning_orig
 
     @property
-    def weighted_detunings(self) -> Sequence[WeightedDetuning]:
+    def weighted_detunings(self) -> Sequence[WeightedDetuning] | None:
         """Detunings applied to individual qubits."""
         return self._weighted_detunings
+
+    @property
+    def dmm(self) -> DetuningMapModulator | None:
+        """Detuning Map Modulator (DMM) applied to individual qubits."""
+        return self._dmm
 
     @property
     def phase(self) -> float:

--- a/qoolqit/drive.py
+++ b/qoolqit/drive.py
@@ -136,6 +136,11 @@ class Drive:
                 "Warning: `weighted_detunings` in Drive is deprecated. "
                 "Use `dmm` instead. This will be removed in a future version."
             )
+            if dmm is not None:
+                raise ValueError(
+                    "Cannot specify both `weighted_detunings` and `dmm`. "
+                    "`weighted_detunings` is deprecated, use `dmm` instead."
+                )
         self._weighted_detunings = weighted_detunings
 
         self._dmm = dmm

--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -146,7 +146,7 @@ def basic_compilation(
     pulser_sequence.declare_channel("rydberg", "rydberg_global")
     pulser_sequence.add(pulser_pulse, "rydberg")
 
-    if len(drive.weighted_detunings) > 0:
+    if drive.weighted_detunings is not None:
         # Add detuning map
         channels = list(device._device.dmm_channels.keys())
         if len(channels) == 0:

--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -10,7 +10,7 @@ from pulser.sequence.sequence import Sequence as PulserSequence
 from pulser.waveforms import Waveform as PulserWaveform
 
 from qoolqit.devices import Device
-from qoolqit.drive import DetuningMapModulator, Drive, Waveform, WeightedDetuning
+from qoolqit.drive import DetuningMapModulator, Drive, Waveform
 from qoolqit.exceptions import CompilationError
 from qoolqit.register import Register
 from qoolqit.waveforms import Interpolated
@@ -151,37 +151,7 @@ def basic_compilation(
         dmm_adder = _DMMAdder(wf_converter, pulser_register, pulser_sequence)
         # support only for a single DMM channel
         dmm_id = list(device._device.dmm_channels.keys())[0]
-        dmm_adder.add_detuning(dmm_id, drive.dmm)
-
-    # to be deprecated, use device.dmm_channels instead
-    # Add weighted detunings if specified in the drive.
-    if drive.weighted_detunings is not None:
-        # Add detuning map
-        channels = list(device._device.dmm_channels.keys())
-        if len(channels) == 0:
-            raise ValueError(
-                f"This program specifies {len(drive.weighted_detunings)} detunings but "
-                "the device doesn't offer any DMM channel to execute them."
-            )
-
-        detuning_adder = _DMMAdder(wf_converter, pulser_register, pulser_sequence)
-
-        # If our device supports reusable channels, we can declare multiple
-        # DMM channels with the same specs
-        if pulser_device.reusable_channels:
-            # Arbitrarily pick the first channel.
-            dmm_id = channels[0]
-            for detuning in drive.weighted_detunings:
-                detuning_adder.add_detuning(dmm_id, detuning)
-        # Do we have enough channels for our detunings?
-        elif len(channels) >= len(drive.weighted_detunings):
-            for dmm_id, detuning in zip(channels, drive.weighted_detunings):
-                detuning_adder.add_detuning(dmm_id, detuning)
-        else:
-            raise ValueError(
-                f"This program specifies {len(drive.weighted_detunings)} detunings but "
-                f"the device only offers {len(channels)} DMM channels to execute them."
-            )
+        dmm_adder.add_dmm(dmm_id, drive.dmm)
 
     return pulser_sequence
 
@@ -206,7 +176,7 @@ class _DMMAdder:
         self._pulser_register = pulser_register
         self._pulser_sequence = pulser_sequence
 
-    def add_detuning(self, dmm_id: str, dmm: WeightedDetuning | DetuningMapModulator) -> None:
+    def add_dmm(self, dmm_id: str, dmm: DetuningMapModulator) -> None:
         # conversion may be needed for pulser register as only str keys are accepted
         converted_weights = {k if isinstance(k, str) else str(k): v for k, v in dmm.weights.items()}
         detuning_map = self._pulser_register.define_detuning_map(detuning_weights=converted_weights)

--- a/qoolqit/execution/compilation_functions.py
+++ b/qoolqit/execution/compilation_functions.py
@@ -10,7 +10,7 @@ from pulser.sequence.sequence import Sequence as PulserSequence
 from pulser.waveforms import Waveform as PulserWaveform
 
 from qoolqit.devices import Device
-from qoolqit.drive import Drive, Waveform, WeightedDetuning
+from qoolqit.drive import DetuningMapModulator, Drive, Waveform, WeightedDetuning
 from qoolqit.exceptions import CompilationError
 from qoolqit.register import Register
 from qoolqit.waveforms import Interpolated
@@ -146,6 +146,15 @@ def basic_compilation(
     pulser_sequence.declare_channel("rydberg", "rydberg_global")
     pulser_sequence.add(pulser_pulse, "rydberg")
 
+    # Add dmm, if specified in the drive.
+    if drive.dmm is not None:
+        dmm_adder = _DMMAdder(wf_converter, pulser_register, pulser_sequence)
+        # support only for a single DMM channel
+        dmm_id = list(device._device.dmm_channels.keys())[0]
+        dmm_adder.add_detuning(dmm_id, drive.dmm)
+
+    # to be deprecated, use device.dmm_channels instead
+    # Add weighted detunings if specified in the drive.
     if drive.weighted_detunings is not None:
         # Add detuning map
         channels = list(device._device.dmm_channels.keys())
@@ -155,7 +164,7 @@ def basic_compilation(
                 "the device doesn't offer any DMM channel to execute them."
             )
 
-        detuning_adder = _DetuningAdder(wf_converter, pulser_register, pulser_sequence)
+        detuning_adder = _DMMAdder(wf_converter, pulser_register, pulser_sequence)
 
         # If our device supports reusable channels, we can declare multiple
         # DMM channels with the same specs
@@ -177,25 +186,32 @@ def basic_compilation(
     return pulser_sequence
 
 
-class _DetuningAdder:
+class _DMMAdder:
+    """Utility class to add a DMM to a Pulser sequence."""
+
     def __init__(
         self,
         wf_converter: WaveformConverter,
         pulser_register: PulserRegister,
         pulser_sequence: PulserSequence,
     ):
+        """Initialize the DMM adder.
+
+        Args:
+            wf_converter: converter of waveforms to pulser units.
+            pulser_register: pulser register to define a detuning map qubit_id -> weight.
+            pulser_sequence: pulser sequence to add DMM to.
+        """
         self._wf_converter = wf_converter
         self._pulser_register = pulser_register
         self._pulser_sequence = pulser_sequence
 
-    def add_detuning(self, dmm_id: str, detuning: WeightedDetuning) -> None:
+    def add_detuning(self, dmm_id: str, dmm: WeightedDetuning | DetuningMapModulator) -> None:
         # conversion may be needed for pulser register as only str keys are accepted
-        converted_weights = {
-            k if isinstance(k, str) else str(k): v for k, v in detuning.weights.items()
-        }
+        converted_weights = {k if isinstance(k, str) else str(k): v for k, v in dmm.weights.items()}
         detuning_map = self._pulser_register.define_detuning_map(detuning_weights=converted_weights)
         self._pulser_sequence.config_detuning_map(detuning_map, dmm_id=dmm_id)
-        waveform = self._wf_converter.convert(detuning.waveform)
+        waveform = self._wf_converter.convert(dmm.waveform)
         self._pulser_sequence.add_dmm_detuning(waveform, dmm_id)
 
 

--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -28,11 +28,23 @@ class QuantumProgram:
         if not isinstance(register, Register):
             raise TypeError("`register` must be of type Register.")
         self._register = register
+
         if not isinstance(drive, Drive):
             raise TypeError("`drive` must be of type Drive.")
+        if drive.dmm is not None:
+            dmm_weights = drive.dmm.weights
+            for qid in dmm_weights.keys():
+                if qid not in register.qubits:
+                    raise ValueError(
+                        "In this QuantumProgram, the drive's detuning modulator map (DMM) "
+                        f"and the register do not match: qubit {qid} appears in the DMM "
+                        "but is not defined in the register."
+                    )
+
         self._drive = drive
         self._compiled_sequence: PulserSequence | None = None
 
+        # to be deprecated
         if drive.weighted_detunings is not None:
             for detuning in drive.weighted_detunings:
                 for key in detuning.weights.keys():

--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -45,17 +45,6 @@ class QuantumProgram:
         self._drive = drive
         self._compiled_sequence: PulserSequence | None = None
 
-        # to be deprecated
-        if drive.weighted_detunings is not None:
-            for detuning in drive.weighted_detunings:
-                for key in detuning.weights.keys():
-                    if key not in register.qubits:
-                        raise ValueError(
-                            "In this QuantumProgram, the drive and the register "
-                            f"do not match: qubit {key} appears in the drive but "
-                            "is not defined in the register."
-                        )
-
     @property
     def register(self) -> Register:
         """The register of qubits."""

--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -32,14 +32,16 @@ class QuantumProgram:
             raise TypeError("`drive` must be of type Drive.")
         self._drive = drive
         self._compiled_sequence: PulserSequence | None = None
-        for detuning in drive.weighted_detunings:
-            for key in detuning.weights.keys():
-                if key not in register.qubits:
-                    raise ValueError(
-                        "In this QuantumProgram, the drive and the register "
-                        f"do not match: qubit {key} appears in the drive but "
-                        "is not defined in the register."
-                    )
+
+        if drive.weighted_detunings is not None:
+            for detuning in drive.weighted_detunings:
+                for key in detuning.weights.keys():
+                    if key not in register.qubits:
+                        raise ValueError(
+                            "In this QuantumProgram, the drive and the register "
+                            f"do not match: qubit {key} appears in the drive but "
+                            "is not defined in the register."
+                        )
 
     @property
     def register(self) -> Register:

--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -6,6 +6,7 @@ from pulser.sequence.sequence import Sequence as PulserSequence
 
 from qoolqit.devices import Device
 from qoolqit.drive import Drive
+from qoolqit.exceptions import CompilationError
 from qoolqit.execution.compilation_functions import CompilerProfile
 from qoolqit.execution.sequence_compiler import SequenceCompiler
 from qoolqit.register import Register
@@ -140,6 +141,13 @@ class QuantumProgram:
                 raise ValueError(
                     "`device_max_duration_ratio` must be between 0 and 1, "
                     f"got {device_max_duration_ratio} instead."
+                )
+
+        # Check if device supports DMM and has a DMM channel
+        if self.drive.dmm is not None:
+            if not device._device.dmm_channels:
+                raise CompilationError(
+                    "The device does not support DMM. Please use a device that supports DMM."
                 )
 
         compiler = SequenceCompiler(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import Callable, Generator
 import numpy as np
 import pytest
 
-from qoolqit.drive import Drive, WeightedDetuning
+from qoolqit.drive import DetuningMapModulator, Drive
 from qoolqit.program import QuantumProgram
 from qoolqit.register import Register
 from qoolqit.waveforms import Ramp, Waveform
@@ -65,11 +65,11 @@ def dmm_program(
         register = random_linear_register_factory(1.0, rng)
         wf_amp = Ramp(1.0, 0.5, 0.5)
         wf_det = Ramp(1.0, -0.2, -0.5)
-        weighted_detuning = WeightedDetuning(
+        dmm = DetuningMapModulator(
             weights={q: uniform(0.1, 0.99) for q in register.qubits_ids},
             waveform=wf_det,
         )
-        drive = Drive(amplitude=wf_amp, detuning=wf_det, weighted_detunings=[weighted_detuning])
+        drive = Drive(amplitude=wf_amp, detuning=wf_det, dmm=dmm)
         return QuantumProgram(register, drive)
 
     yield _generate_program

--- a/tests/test_compilation/test_compile_to.py
+++ b/tests/test_compilation/test_compile_to.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
+from pulser.sampler import sample
 
-from qoolqit import AnalogDevice, Constant, Drive, QuantumProgram, Register
+from qoolqit import AnalogDevice, Constant, Drive, MockDevice, QuantumProgram, Register
 from qoolqit.drive import DetuningMapModulator
 from qoolqit.exceptions import CompilationError
 from qoolqit.execution.compilation_functions import CompilerProfile
@@ -35,16 +37,32 @@ def test_dmm_not_supported() -> None:
         program.compile_to(device=AnalogDevice())
 
 
-""" @pytest.mark.parametrize("profile", [CompilerProfile.MAX_ENERGY, CompilerProfile.WORKING_POINT])
+@pytest.mark.parametrize("profile", [CompilerProfile.MAX_ENERGY, CompilerProfile.WORKING_POINT])
 def test_compilation_with_dmm(profile: CompilerProfile) -> None:
     register = Register(qubits={"q0": (0.0, 0.7), "q1": (-0.5, -0.5), "q2": (0.5, -0.5)})
 
+    amplitude = Constant(5.0, 0.5)
+    detuning = Constant(5.0, -1.23)
     dmm = DetuningMapModulator(
-        waveform=Constant(4.0, -1.0), weights={"q0": 0.1, "q1": 0.2, "q2": 0.9}
+        waveform=Constant(5.0, -1.23), weights={"q0": 0.1, "q1": 0.2, "q2": 0.9}
     )
-    drive = Drive(amplitude=Constant(150.0, 0.01), dmm=dmm)
+    drive = Drive(amplitude=amplitude, detuning=detuning, dmm=dmm)
     program = QuantumProgram(register=register, drive=drive)
 
     # Test compilation on the default profile
-    program.compile_to(device=DigitalAnalogDevice(), profile=profile)
-    assert program.is_compiled """
+    program.compile_to(device=MockDevice(), profile=profile)
+    assert program.is_compiled
+
+    # check pulser sequence contains expected DMM values by sampling the sequence
+    pulser_sequence = program.compiled_sequence
+    assert set(pulser_sequence.declared_channels.keys()) == {"rydberg", "dmm_0"}
+
+    pulser_sequence_sample = sample(pulser_sequence)
+    rydberg_sample = pulser_sequence_sample.channel_samples["rydberg"]
+    dmm_sample = pulser_sequence_sample.channel_samples["dmm_0"]
+
+    # check detunings are scaled correctly by compilation
+    np.testing.assert_allclose(rydberg_sample.det, dmm_sample.det, atol=1e-8)
+
+    dmm_weights = dmm_sample.detuning_map.weights
+    assert dmm_weights == (0.1, 0.2, 0.9)

--- a/tests/test_compilation/test_compile_to.py
+++ b/tests/test_compilation/test_compile_to.py
@@ -39,6 +39,7 @@ def test_dmm_not_supported() -> None:
 
 @pytest.mark.parametrize("profile", [CompilerProfile.MAX_ENERGY, CompilerProfile.WORKING_POINT])
 def test_compilation_with_dmm(profile: CompilerProfile) -> None:
+    """Test compilation of a program with a DMM."""
     register = Register(qubits={"q0": (0.0, 0.7), "q1": (-0.5, -0.5), "q2": (0.5, -0.5)})
 
     amplitude = Constant(5.0, 0.5)

--- a/tests/test_compilation/test_compile_to.py
+++ b/tests/test_compilation/test_compile_to.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from qoolqit import AnalogDevice, Constant, Drive, QuantumProgram, Register
+from qoolqit.drive import DetuningMapModulator
+from qoolqit.exceptions import CompilationError
 from qoolqit.execution.compilation_functions import CompilerProfile
 
 
@@ -18,3 +22,29 @@ def test_compilation_single_qubit(profile: CompilerProfile) -> None:
     # Test compilation on the default profile
     program.compile_to(device=AnalogDevice(), profile=profile)
     assert program.is_compiled
+
+
+def test_dmm_not_supported() -> None:
+    """Test compilation of a program with a DMM but the device does not support it."""
+    mock_register = MagicMock(spec=Register)
+    mock_dmm = MagicMock(spec=DetuningMapModulator, weights={})
+    mock_drive = MagicMock(spec=Drive, dmm=mock_dmm)
+    program = QuantumProgram(register=mock_register, drive=mock_drive)
+    with pytest.raises(CompilationError, match="The device does not support DMM"):
+        # AnalogDevice does not support DMM
+        program.compile_to(device=AnalogDevice())
+
+
+""" @pytest.mark.parametrize("profile", [CompilerProfile.MAX_ENERGY, CompilerProfile.WORKING_POINT])
+def test_compilation_with_dmm(profile: CompilerProfile) -> None:
+    register = Register(qubits={"q0": (0.0, 0.7), "q1": (-0.5, -0.5), "q2": (0.5, -0.5)})
+
+    dmm = DetuningMapModulator(
+        waveform=Constant(4.0, -1.0), weights={"q0": 0.1, "q1": 0.2, "q2": 0.9}
+    )
+    drive = Drive(amplitude=Constant(150.0, 0.01), dmm=dmm)
+    program = QuantumProgram(register=register, drive=drive)
+
+    # Test compilation on the default profile
+    program.compile_to(device=DigitalAnalogDevice(), profile=profile)
+    assert program.is_compiled """

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -42,6 +42,11 @@ def test_drive_init_and_composition(amp_wf: Waveform, det_wf: Waveform) -> None:
 
     drive = Drive(amplitude=amp_wf, detuning=det_wf)
 
+    with pytest.raises(
+        NotImplementedError, match="Composing with object of type <class 'float'> not supported."
+    ):
+        drive >> 1.0  # type: ignore [operator]
+
     duration_amp = amp_wf.duration
     duration_det = det_wf.duration
 

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -5,7 +5,7 @@ import random
 
 import pytest
 
-from qoolqit.drive import DetuningMapModulator, Drive, WeightedDetuning
+from qoolqit.drive import DetuningMapModulator, Drive
 from qoolqit.waveforms import Constant, Delay, PiecewiseLinear, Ramp
 from qoolqit.waveforms.base_waveforms import Waveform
 
@@ -85,21 +85,6 @@ def test_drive_duration_with_delays(amp_duration: float, det_duration: float) ->
     det_wf = Ramp(det_duration, -1.0, 0.0)
     drive = Drive(amplitude=amp_wf, detuning=det_wf)
     assert drive.duration == max(amp_duration, det_duration)
-
-
-def test_weighted_detuning() -> None:
-    drive = Drive(
-        amplitude=Ramp(10, 0.0, 1.0),
-        weighted_detunings=[WeightedDetuning(weights={0: 1}, waveform=Ramp(1.0, -0.2, -0.5))],
-    )
-    weighted_detunings = drive.weighted_detunings
-    assert isinstance(weighted_detunings, list)
-    assert len(weighted_detunings) == 1
-
-    weighted_detuning = weighted_detunings[0]
-    assert isinstance(weighted_detuning, WeightedDetuning)
-    assert weighted_detuning.weights == {0: 1}
-    assert isinstance(weighted_detuning.waveform, Ramp)
 
 
 def test_dmm_init() -> None:

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -5,7 +5,7 @@ import random
 
 import pytest
 
-from qoolqit.drive import Drive, WeightedDetuning
+from qoolqit.drive import DetuningMapModulator, Drive, WeightedDetuning
 from qoolqit.waveforms import Constant, Delay, PiecewiseLinear, Ramp
 from qoolqit.waveforms.base_waveforms import Waveform
 
@@ -82,28 +82,34 @@ def test_drive_duration_with_delays(amp_duration: float, det_duration: float) ->
     assert drive.duration == max(amp_duration, det_duration)
 
 
-def test_error_weighted_detuning_positive() -> None:
-    with pytest.raises(ValueError, match="WeightedDetuning waveform must be negative."):
-        WeightedDetuning(weights={0: 1}, waveform=Ramp(1.0, 0.2, 0.5))
-
-
-@pytest.mark.parametrize(
-    "amp_wf, det_wf",
-    [
-        (Ramp(10.0, 1.0, 0.0), Ramp(12.1, -2.1, 2.1)),
-        (
-            Constant(10.0, math.pi),
-            PiecewiseLinear(
-                [4.60132814, 4.18237748, 5.21984795, 3.5963718],
-                [0.1443786, -0.2027756, 0.46146151, 0.07375925, 0.52915184],
-            ),
-        ),
-    ],
-)
-def test_weighted_detuning(amp_wf: Waveform, det_wf: Waveform) -> None:
+def test_weighted_detuning() -> None:
     drive = Drive(
-        amplitude=amp_wf,
-        detuning=det_wf,
+        amplitude=Ramp(10, 0.0, 1.0),
         weighted_detunings=[WeightedDetuning(weights={0: 1}, waveform=Ramp(1.0, -0.2, -0.5))],
     )
-    assert len(drive.weighted_detunings) == 1
+    weighted_detunings = drive.weighted_detunings
+    assert isinstance(weighted_detunings, list)
+    assert len(weighted_detunings) == 1
+
+    weighted_detuning = weighted_detunings[0]
+    assert isinstance(weighted_detuning, WeightedDetuning)
+    assert weighted_detuning.weights == {0: 1}
+    assert isinstance(weighted_detuning.waveform, Ramp)
+
+
+def test_dmm_init() -> None:
+    positive_wf = Ramp(10.0, -10.0, 1.0)
+    negative_wf = Ramp(10.0, -1.0, -2.0)
+
+    valid_weights = {0: 0.1, 1: 0.2, 2: 0.3}
+    invalid_weights = {0: 1.1, 1: 0.3}
+
+    with pytest.raises(ValueError, match="`weights` must be a dictionary of values in \\[0, 1\\]."):
+        DetuningMapModulator(negative_wf, weights=invalid_weights)
+
+    with pytest.raises(ValueError, match="`waveform` must be negative for all times."):
+        DetuningMapModulator(positive_wf, weights=valid_weights)
+
+    dmm = DetuningMapModulator(negative_wf, weights=valid_weights)
+    assert isinstance(dmm.waveform, Ramp)
+    assert dmm.weights == valid_weights

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -7,7 +7,7 @@ from pulser.sequence import Sequence as PulserSequence
 
 from qoolqit import AnalogDevice, DataGraph, DigitalAnalogDevice, MockDevice
 from qoolqit.devices import Device
-from qoolqit.drive import Drive
+from qoolqit.drive import DetuningMapModulator, Drive
 from qoolqit.exceptions import CompilationError
 from qoolqit.program import QuantumProgram
 from qoolqit.register import Register
@@ -24,6 +24,17 @@ def test_program_init() -> None:
 
     with pytest.raises(ValueError, match="Program has not been compiled"):
         program.compiled_sequence
+
+
+def test_program_init_wrong_type() -> None:
+    register = Register(qubits={"q0": (-0.5, 0.0), "q1": (0.5, 0.0)})
+    drive = Drive(amplitude=Constant(10.0, 1.0), detuning=Constant(10.0, -1.0))
+
+    with pytest.raises(TypeError, match="`register` must be of type Register."):
+        QuantumProgram(register=123, drive=drive)  # type: ignore [arg-type]
+
+    with pytest.raises(TypeError, match="`drive` must be of type Drive."):
+        QuantumProgram(register=register, drive=123)  # type: ignore [arg-type]
 
 
 @pytest.mark.parametrize(
@@ -106,3 +117,23 @@ def test_max_duration_ratio_error() -> None:
 
     with pytest.raises(ValueError, match="Cannot set `device_max_duration_ratio`"):
         program.compile_to(device=MockDevice(), device_max_duration_ratio=0.5)
+
+
+def test_program_with_dmm() -> None:
+    register = Register(qubits={"q0": (0.0, 0.0), "q1": (1.3, 0.0)})
+
+    valid_weights = {"q0": 0.1, "q1": 0.2}
+
+    dmm = DetuningMapModulator(waveform=Constant(4.0, -1.0), weights=valid_weights)
+    drive = Drive(amplitude=Constant(5.0, 1.0), detuning=Constant(5.0, 1.0), dmm=dmm)
+    program = QuantumProgram(register=register, drive=drive)
+
+    invalid_weights = {"q0": 0.1, "q1": 0.2, "wrong_qubit_id": 0.3}
+
+    dmm = DetuningMapModulator(waveform=Constant(4.0, -1.0), weights=invalid_weights)
+    drive = Drive(amplitude=Constant(5.0, 1.0), detuning=Constant(5.0, 1.0), dmm=dmm)
+    with pytest.raises(
+        ValueError,
+        match="qubit wrong_qubit_id appears in the DMM but is not defined in the register.",
+    ):
+        QuantumProgram(register=register, drive=drive)


### PR DESCRIPTION
Resolves #294 
- [x] rename  `list[WeightedDetuning]` to `DetuningMapModulator`
- [x] check weights keys in {qubit_ids}, in program creation

## Changes
- rename `WeightedDetuning` -> `DetuningMapModulator`
- support only single `dmm: DetuningMapModulator`  instance in Drive
    context: real devices will only have one dmm channel. For emulation of multiple channels we will provide directly local addressability.
- tests

## Example
```python
from qoolqit import Register, Drive, QuantumProgram, DataGraph
from qoolqit.waveforms import Constant, PiecewiseLinear, Ramp, Interpolated
from qoolqit.drive import DetuningMapModulator
from qoolqit.devices import DigitalAnalogDevice

# Create the register
graph = DataGraph.circle(5)
register = Register.from_graph(embedded_graph)

# Defining the annealing parameters
omega = 0.8
delta_i = -2.0 * omega
delta_f = -delta_i
T = 25.0

amplitude = Interpolated(T, values=[0.0, omega/2, omega, omega/2, 0])
detuning = Ramp(T, delta_i, delta_f)
dmm = DetuningMapModulator(waveform=Constant(T,-1.0), weights={0:0.1})
drive = Drive(amplitude = amplitude, detuning=detuning, dmm=dmm)  
program = QuantumProgram(register=register, drive=drive)

# Compile the program to the device
program.compile_to(DigitalAnalogDevice())

# Draw the program
program.compiled_sequence.draw(draw_detuning_maps=True)
```
<img width="339" height="433" alt="image" src="https://github.com/user-attachments/assets/d97d3d37-3492-4ae3-9e24-cf7f39e8ea45" />
<img width="1696" height="611" alt="image" src="https://github.com/user-attachments/assets/695e6b14-7deb-4e87-9ecb-b203256fa80b" />

## Notes
- documentation and example in notebook to be added separately in #279 
