### PR TITLE
remove markdown-exec

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,6 @@ markdown_extensions:
 plugins:
 - search
 - section-index
-- markdown-exec
 - autorefs
 - mkdocs-jupyter:
     include: ["*.ipynb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dev = [
   "mkdocstrings-python",
   "mkdocs-section-index",
   "mkdocs-jupyter",
-  "markdown-exec",
   "mike",
 ]
 


### PR DESCRIPTION
Resolves #318 

> 
> Following the parent issue #226 
> 
> As `mkdocs`, its plugin `markdown-exec` will not be maintained.
> Since all `markdown-exec` has been removed from the docs, we can safely remove the dependency on such plugin.
