### PR TITLE
remove polyfill form mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,7 +133,6 @@ plugins:
 # For mathjax
 extra_javascript:
   - extras/javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 watch:


### PR DESCRIPTION
Resolves #330 

> 
> Recommended in old mkdocs.yml config but now is useless and not safe.
> Latest [mkdocs-material documentation](https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax->mkdocsyml) do not mention it.
> 
> ### Problem
> The documentation site currently loads JavaScript from `polyfill.io`, which poses a significant security risk. The polyfill.io service was sold and has been compromised with malicious code that can be injected into websites using the service.
> 
> ### Impact
> - **High security risk**: Malicious JavaScript could be executed on the documentation site
> - **Supply chain attack vector**: Third-party CDN compromise affects all sites loading from polyfill.io
> - **User safety**: Visitors to the documentation could be exposed to malicious scripts
> 
> ### Solution
> Remove the polyfill.io reference from `mkdocs.yml`:
> 
> ```yaml
> # Current (vulnerable)
> extra_javascript:
>   - extras/javascripts/mathjax.js
>   - https://polyfill.io/v3/polyfill.min.js?features=es6  # REMOVE THIS LINE
>   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
> 
> # Secure alternative
> extra_javascript:
>   - extras/javascripts/mathjax.js
>   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
> ```
> 
> ### Why it's safe to remove
> - **ES6 is widely supported**: All modern browsers (Chrome 51+, Firefox 54+, Safari 10+, Edge 15+) natively support ES6
> - **Documentation audience**: Developers visiting documentation typically use modern browsers
> - **MathJax compatibility**: MathJax 3.x works without ES6 polyfills on supported browsers
> 
> ### References
> - [polyfill-service security issue](https://github.com/polyfillpolyfill/polyfill-service/issues/2873)
> - https://github.com/squidfunk/mkdocs-material/issues/7295
> - [Browser ES6 support table](https://caniuse.com/es6)
> 
> ### Priority
> **High** - This is a security vulnerability that should be addressed immediately.
> 
> ### Acceptance Criteria
> - [x] Remove polyfill.io reference from `mkdocs.yml`
> - [x] Verify documentation site still renders MathJax correctly