### PR TITLE
fix datagraph from matrix overwrite input matrix diagonal

### DIFF
--- a/qoolqit/graphs/data_graph.py
+++ b/qoolqit/graphs/data_graph.py
@@ -277,14 +277,14 @@ class DataGraph(BaseGraph):
         else:
             node_weights = {i: diag[i].item() for i in range(n_nodes)}
 
-        data_copy = data.copy()
-        data_copy[data <= 1e-7] = 0.0
-        non_zero = data_copy.nonzero()
+        non_zero = data.nonzero()
         i_list = non_zero[0].tolist()
         j_list = non_zero[1].tolist()
 
-        edge_list = [(i, j) for i, j in zip(i_list, j_list) if i < j]
-        edge_weights = {(i, j): data_copy[i, j].item() for i, j in edge_list}
+        edge_list = [
+            (i, j) for i, j in zip(i_list, j_list) if i < j and (np.abs(data[i, j]) >= 1e-7)
+        ]
+        edge_weights = {(i, j): data[i, j].item() for i, j in edge_list}
 
         graph = cls.from_nodes(range(n_nodes))
         graph.add_edges_from(edge_list)

--- a/qoolqit/graphs/data_graph.py
+++ b/qoolqit/graphs/data_graph.py
@@ -269,12 +269,12 @@ class DataGraph(BaseGraph):
         if not np.allclose(data, data.T, rtol=0.0, atol=1e-7):
             raise ValueError("Matrix must be symmetric.")
 
-        # absolute values below this tolerance are treated as zeros.
+        # Absolute values below this tolerance are treated as zeros.
+        # The corresponding node or edge weight is neglected (weight = None).
         nonzero_tol = 1e-7
 
         diag = np.diag(data)
         n_nodes = len(diag)
-        node_weights = {i: diag[i] for i in range(n_nodes)}
         if np.allclose(diag, np.zeros(n_nodes), rtol=0.0, atol=nonzero_tol):
             node_weights = {i: None for i in range(n_nodes)}
         else:

--- a/qoolqit/graphs/data_graph.py
+++ b/qoolqit/graphs/data_graph.py
@@ -269,20 +269,22 @@ class DataGraph(BaseGraph):
         if not np.allclose(data, data.T, rtol=0.0, atol=1e-7):
             raise ValueError("Matrix must be symmetric.")
 
+        # absolute values below this tolerance are treated as zeros.
+        nonzero_tol = 1e-7
+
         diag = np.diag(data)
         n_nodes = len(diag)
         node_weights = {i: diag[i] for i in range(n_nodes)}
-        if np.allclose(diag, np.zeros(n_nodes), rtol=0.0, atol=1e-7):
+        if np.allclose(diag, np.zeros(n_nodes), rtol=0.0, atol=nonzero_tol):
             node_weights = {i: None for i in range(n_nodes)}
         else:
             node_weights = {i: diag[i].item() for i in range(n_nodes)}
 
-        non_zero = data.nonzero()
-        i_list = non_zero[0].tolist()
-        j_list = non_zero[1].tolist()
-
         edge_list = [
-            (i, j) for i, j in zip(i_list, j_list) if i < j and (np.abs(data[i, j]) >= 1e-7)
+            (i, j)
+            for i in range(n_nodes)
+            for j in range(i + 1, n_nodes)
+            if (np.abs(data[i, j]) >= nonzero_tol)
         ]
         edge_weights = {(i, j): data[i, j].item() for i, j in edge_list}
 

--- a/qoolqit/graphs/data_graph.py
+++ b/qoolqit/graphs/data_graph.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 import numpy as np
-from numpy.typing import ArrayLike
 
 from .base_graph import BaseGraph
 from .utils import random_coords
@@ -18,8 +17,6 @@ from .utils import random_coords
 if TYPE_CHECKING:
     import torch
     import torch_geometric
-
-ATOL_32 = 1e-7
 
 
 class DataGraph(BaseGraph):
@@ -257,7 +254,7 @@ class DataGraph(BaseGraph):
         return graph
 
     @classmethod
-    def from_matrix(cls, data: ArrayLike) -> DataGraph:
+    def from_matrix(cls, data: np.ndarray) -> DataGraph:
         """Constructs a graph from a symmetric square matrix.
 
         The diagonal values are set as the node weights. For each entry (i, j)
@@ -265,28 +262,29 @@ class DataGraph(BaseGraph):
         M[i, j] is set as its weight.
 
         Arguments:
-            data: symmetric square matrix.
+            data: real symmetric square matrix.
         """
         if data.ndim != 2:
             raise ValueError("2D Matrix required.")
-        if not np.allclose(data, data.T, rtol=0.0, atol=ATOL_32):
+        if not np.allclose(data, data.T, rtol=0.0, atol=1e-7):
             raise ValueError("Matrix must be symmetric.")
 
         diag = np.diag(data)
         n_nodes = len(diag)
         node_weights = {i: diag[i] for i in range(n_nodes)}
-        if np.allclose(diag, np.zeros(n_nodes), rtol=0.0, atol=ATOL_32):
+        if np.allclose(diag, np.zeros(n_nodes), rtol=0.0, atol=1e-7):
             node_weights = {i: None for i in range(n_nodes)}
         else:
             node_weights = {i: diag[i].item() for i in range(n_nodes)}
 
-        data[data <= ATOL_32] = 0.0
-        non_zero = data.nonzero()
+        data_copy = data.copy()
+        data_copy[data <= 1e-7] = 0.0
+        non_zero = data_copy.nonzero()
         i_list = non_zero[0].tolist()
         j_list = non_zero[1].tolist()
 
         edge_list = [(i, j) for i, j in zip(i_list, j_list) if i < j]
-        edge_weights = {(i, j): data[i, j].item() for i, j in edge_list}
+        edge_weights = {(i, j): data_copy[i, j].item() for i, j in edge_list}
 
         graph = cls.from_nodes(range(n_nodes))
         graph.add_edges_from(edge_list)

--- a/tests/test_graphs/test_data_graph.py
+++ b/tests/test_graphs/test_data_graph.py
@@ -93,15 +93,16 @@ def test_datagraph_from_matrix(n_nodes: int) -> None:
     node_weights = list(graph.node_weights.values())
     np.testing.assert_allclose(node_weights, data_diag)
 
-    # Remove diagonal and some random values from the data
+    # Build a fresh matrix for the second sub-test: zero out the diagonal and some random edges
     almost_zero = ATOL_64
-    np.fill_diagonal(data, almost_zero)
+    data2 = data_copy.copy()
+    np.fill_diagonal(data2, almost_zero)
     random_edges_removal = random_edge_list(range(n_nodes), k=4)
     i_list, j_list = zip(*random_edges_removal)
-    data[i_list, j_list] = almost_zero
-    data[j_list, i_list] = almost_zero
+    data2[i_list, j_list] = almost_zero
+    data2[j_list, i_list] = almost_zero
 
-    graph = DataGraph.from_matrix(data)
+    graph = DataGraph.from_matrix(data2)
 
     assert not graph.has_node_weights
     assert graph.has_edge_weights
@@ -112,7 +113,7 @@ def test_datagraph_from_matrix(n_nodes: int) -> None:
     n_edges = graph.number_of_edges()
     idx = [2 * i for i in range(n_edges)]
 
-    data_edge_weights = np.sort(data[data >= 1e-7])[idx]
+    data_edge_weights = np.sort(data2[data2 >= 1e-7])[idx]
     edge_weights = sorted(list(graph.edge_weights.values()))
 
     np.testing.assert_allclose(edge_weights, data_edge_weights)

--- a/tests/test_graphs/test_data_graph.py
+++ b/tests/test_graphs/test_data_graph.py
@@ -77,8 +77,12 @@ def test_datagraph_from_matrix(n_nodes: int) -> None:
         graph = DataGraph.from_matrix(data)
 
     data = data + data.T
+    data_copy = data.copy()  # Make a copy to test the original data
 
     graph = DataGraph.from_matrix(data)
+
+    # Check input data matrix has not been modified
+    np.testing.assert_equal(data, data_copy)
 
     assert len(graph.node_weights) == graph.number_of_nodes()
     assert len(graph.edge_weights) == graph.number_of_edges()
@@ -87,7 +91,7 @@ def test_datagraph_from_matrix(n_nodes: int) -> None:
 
     data_diag = np.diag(data)
     node_weights = list(graph.node_weights.values())
-    assert np.allclose(node_weights, data_diag)
+    np.testing.assert_allclose(node_weights, data_diag)
 
     # Remove diagonal and some random values from the data
     almost_zero = ATOL_64
@@ -108,10 +112,10 @@ def test_datagraph_from_matrix(n_nodes: int) -> None:
     n_edges = graph.number_of_edges()
     idx = [2 * i for i in range(n_edges)]
 
-    data_edge_weights = np.sort(data[data.nonzero()])[idx]
+    data_edge_weights = np.sort(data[data >= 1e-7])[idx]
     edge_weights = sorted(list(graph.edge_weights.values()))
 
-    assert np.allclose(edge_weights, data_edge_weights)
+    np.testing.assert_allclose(edge_weights, data_edge_weights)
 
 
 def test_triangular() -> None:


### PR DESCRIPTION
Resolves #336 

> Currently, `DataGraph.from_matrix` overwrite input matrix diagonal.
> 
> ## to reproduce
> 
> ```python
> import numpy as np
> from qoolqit.graphs import DataGraph
> 
> Q = np.array(
>     [
>         [-10.0, 19.7365809, 19.7365809, 5.42015853, 5.42015853],
>         [19.7365809, -10.0, 20.67626392, 0.17675796, 0.85604541],
>         [19.7365809, 20.67626392, -10.0, 0.85604541, 0.17675796],
>         [5.42015853, 0.17675796, 0.85604541, -10.0, 0.32306662],
>         [5.42015853, 0.85604541, 0.17675796, 0.32306662, -10.0],
>     ]
> )
> 
> graph = DataGraph.from_matrix(Q)
> print(Q)
> ```
> which shows
> 
> ```sh
> [[ 0.         19.7365809  19.7365809   5.42015853  5.42015853]
>  [19.7365809   0.         20.67626392  0.17675796  0.85604541]
>  [19.7365809  20.67626392  0.          0.85604541  0.17675796]
>  [ 5.42015853  0.17675796  0.85604541  0.          0.32306662]
>  [ 5.42015853  0.85604541  0.17675796  0.32306662  0.        ]]
> ```
> 
> so the input is altered.
> 
> ## To solve
> Do not allow `from_matrix` to alter input matrix.