### PR TITLE
simplify composite waveform function

### DIFF
--- a/qoolqit/waveforms/base_waveforms.py
+++ b/qoolqit/waveforms/base_waveforms.py
@@ -237,8 +237,8 @@ class CompositeWaveform(Waveform):
             idx = idx - 1
 
         local_t = t - self.times[idx]
-        value = self.waveforms[idx](local_t)
-        return cast(float, value)
+        value: float = self.waveforms[idx](local_t)
+        return value
 
     def max(self) -> float:
         """Get the maximum value of the waveform."""

--- a/qoolqit/waveforms/base_waveforms.py
+++ b/qoolqit/waveforms/base_waveforms.py
@@ -73,7 +73,7 @@ class Waveform(ABC):
 
     @abstractmethod
     def function(self, t: float) -> float:
-        """Evaluates the waveform function at a given time t."""
+        """Evaluates the waveform function at time t."""
         ...
 
     def _approximate_min_max(self) -> None:
@@ -230,19 +230,15 @@ class CompositeWaveform(Waveform):
         return len(self.waveforms)
 
     def function(self, t: float) -> float:
-        """Identifies the right waveform in the composition and evaluates it at time t."""
         idx = np.searchsorted(self.times, t, side="right") - 1
-        if idx == -1:
-            return 0.0
+
+        # clamp idx to the last waveform
         if idx == self.n_waveforms:
-            if t == self.times[-1]:
-                idx = idx - 1
-            else:
-                return 0.0
+            idx = idx - 1
 
         local_t = t - self.times[idx]
-        value: float = self.waveforms[idx](local_t)
-        return value
+        value = self.waveforms[idx](local_t)
+        return cast(float, value)
 
     def max(self) -> float:
         """Get the maximum value of the waveform."""

--- a/qoolqit/waveforms/base_waveforms.py
+++ b/qoolqit/waveforms/base_waveforms.py
@@ -231,10 +231,8 @@ class CompositeWaveform(Waveform):
 
     def function(self, t: float) -> float:
         idx = np.searchsorted(self.times, t, side="right") - 1
-
-        # clamp idx to the last waveform
-        if idx == self.n_waveforms:
-            idx = idx - 1
+        # clip to valid waveform index range
+        idx = np.clip(idx, 0, self.n_waveforms - 1)
 
         local_t = t - self.times[idx]
         value: float = self.waveforms[idx](local_t)


### PR DESCRIPTION
Resolves #361 

> Remove dead code in `CompositeWaveform.function`
> 
> ## Description
> The logic inside `CompositeWaveform.function` can be simplified.
> Only the last time of the last waveform needs to be treated separately since `np.seachsorted(side="right")` excludes it.
> After that point the last waveform naturally evaluates to 0 outside bounds because of `Waveform.function` and `_single_call` implementation.

No additional tests since it is just removing dead code