### PR TITLE
bump numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ classifiers = [
 ]
 
 dependencies = [
-  "pulser[torch]>=1.8.0",
   "networkx>=3.4",
+  "numpy>=2",
+  "pulser[torch]>=1.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Resolves #362 

Bump numpy version to `numpy>=2`.
Requires up to date version of numpy. See also https://github.com/pasqal-io/qubo-solver/pull/205