### PR TITLE
pin mkdocs to 1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
   "pre-commit",
   "ipykernel",
   "nbmake",
-  "mkdocs",
+  "mkdocs==1.6.1",
   "mkdocs-material",
   "mkdocstrings-python",
   "mkdocs-section-index",


### PR DESCRIPTION
Resolves #382 

> `mkodcs` is not actively mantained.
> To prevent unexpected changes, pin its version to the last release that we know works for us, which is v1.6.1
