### PR TITLE
disable parameter heading in API docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,11 +111,10 @@ plugins:
           heading_level: 2
           inherited_members: true
           merge_init_into_class: true
-          parameter_headings: true
-          type_parameter_headings: true
           preload_modules: [qoolqit, pulser]
           relative_crossrefs: true
           scoped_crossrefs: true
+          separate_signature: true
           show_bases: false
           show_inheritance_diagram: false
           show_root_heading: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,7 @@ plugins:
           preload_modules: [qoolqit, pulser]
           relative_crossrefs: true
           scoped_crossrefs: true
-          separate_signature: true
+          separate_signature: true  # uses black/ruff if available to format signatures
           show_bases: false
           show_inheritance_diagram: false
           show_root_heading: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
   "mkdocs-section-index",
   "mkdocs-jupyter",
   "mike",
+  "ruff>=0.15.21",
 ]
 
 [project.urls]


### PR DESCRIPTION
Resolves #379 

## Changes

- remove `parameter_heading` option in `mkdocstring` which clutters the right table of contents with arleady available info in the signature.
- add `separate_signature` option which renders the signature as a block of code. 
- add `ruff` to dev environment as `separate_signature` option needs black/ruff to format the signature. 

### Before
<img width="70%" alt="Screenshot from 2026-07-10 09-18-24" src="https://github.com/user-attachments/assets/9388201c-a545-4ab5-970b-cc2492a55718" />

### After
<img width="70%" alt="Screenshot from 2026-07-10 09-29-59" src="https://github.com/user-attachments/assets/de562618-7c70-4ab7-b357-1b9722115db4" />
