### PR TITLE
validate input in register default constructor

### DIFF
--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator
+from numpy.typing import ArrayLike
 
 from qoolqit.graphs import DataGraph, all_node_pairs, distances
 from qoolqit.graphs.utils import radial_distances
@@ -46,7 +47,9 @@ class Register:
         >>> reg = Register({"a": np.array([0.0, 0.0]), "b": np.array([1.0, 0.0])})
     """
 
-    def __init__(self, qubits: dict) -> None:
+    def __init__(
+        self, qubits: dict[str, ArrayLike | torch.Tensor] | dict[int, ArrayLike | torch.Tensor]
+    ) -> None:
         """Default constructor for the Register.
 
         Args:

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -22,20 +22,20 @@ except ImportError:
 
 
 class Register:
-    """The Register in QoolQit, representing a set of qubit ids with coordinates.
+    """A QoolQit register mapping qubit IDs to 2D coordinates.
 
     Attributes:
-        qubits: a dictionary of qubit ids and respective coordinates {q: (x, y),...}.
-        qubits_ids: a list of qubit ids.
+        qubits: a dictionary of qubit IDs and respective coordinates {q: (x, y),...}.
+        qubits_ids: a list of qubit IDs.
         n_qubits: the number of qubits in the register.
 
     Examples:
-        From a dictionary of qubit ids and coordinates:
+        From a dictionary of qubit IDs and coordinates:
 
         >>> reg = Register({"a": (0.0, 0.0), "b": (1.0, 0.0), "c": (0.0, 1.0)})
         >>> reg = Register({0: (0.0, 0.0), 1: (1.0, 0.0), 2: (0.0, 1.0)})
 
-        From a list of coordinates (qubit ids are assigned automatically as integers):
+        From a list of coordinates (qubit IDs are assigned automatically as integers):
 
         >>> reg = Register.from_coordinates([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)])
 

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from math import ceil
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -10,13 +11,23 @@ from matplotlib.ticker import MultipleLocator
 from qoolqit.graphs import DataGraph, all_node_pairs, distances
 from qoolqit.graphs.utils import radial_distances
 
+if TYPE_CHECKING:
+    import torch
+
+try:
+    import torch
+
+    _has_torch = True
+except ImportError:
+    _has_torch = False
+
 
 class Register:
     """The Register in QoolQit, representing a set of qubits with coordinates.
 
     Attributes:
         qubits: a dictionary of qubits and respective coordinates {q: (x, y),...}.
-        qubit_ids: a list of qubit ids.
+        qubits_ids: a list of qubit ids.
         n_qubits: the number of qubits in the register.
 
     Examples:
@@ -44,7 +55,8 @@ class Register:
         Raises:
             TypeError: If the qubits argument is not a dictionary.
             ValueError: If the qubits argument is empty.
-            ValueError: If the coordinate for a qubit is not a tuple, list or array of length 2.
+            ValueError: If the coordinate for a qubit is not a tuple, list or
+                numpy or torch array of length 2.
         """
         if not isinstance(qubits, dict):
             raise TypeError(
@@ -54,21 +66,26 @@ class Register:
         if len(qubits) == 0:
             raise ValueError("Register cannot be empty.")
 
+        parsed = {}
         for key, val in qubits.items():
-            val_array = val
-            if isinstance(val, (tuple, list)):
-                val_array = np.asarray(val, dtype=float)
-            valid = val_array.ndim == 1 and val_array.shape[0] == 2
-            if not valid:
+            try:
+                if _has_torch and isinstance(val, torch.Tensor):
+                    parsed[key] = torch.asarray(val, dtype=torch.float64)
+                else:
+                    parsed[key] = np.asarray(val, dtype=float)
+            except (ValueError, TypeError) as err:
                 raise ValueError(
-                    f"Coordinate for qubit {key!r} must be a tuple, list, or array of length 2, "
-                    f"got {val!r}."
+                    f"Coordinate for qubit {key!r} must be castable to an array of floats."
+                ) from err
+
+            converted = parsed[key]
+            if converted.ndim != 1 or converted.shape[0] != 2:
+                raise ValueError(
+                    f"Coordinate for qubit {key!r} must be a 1D "
+                    f"tuple, list, or array of length 2, got {val!r}."
                 )
 
-        self._qubits = {
-            key: (np.asarray(val, dtype=float) if isinstance(val, (tuple, list)) else val)
-            for key, val in qubits.items()
-        }
+        self._qubits = parsed
 
     @classmethod
     def from_graph(cls, graph: DataGraph) -> Register:
@@ -114,7 +131,7 @@ class Register:
     @property
     def n_qubits(self) -> int:
         """Number of qubits in the Register."""
-        return len(self.qubits)
+        return len(self._qubits)
 
     def distances(self) -> dict:
         """Distance between each qubit pair."""
@@ -151,7 +168,14 @@ class Register:
         fig, ax = plt.subplots(1, 1, figsize=(4, 4), dpi=150)
         ax.set_aspect("equal")
 
-        x_coords, y_coords = zip(*self.qubits.values())
+        x_coords, y_coords = zip(
+            *[
+                np.asarray(
+                    v.detach() if (_has_torch and isinstance(v, torch.Tensor)) else v, dtype=float
+                )
+                for v in self.qubits.values()
+            ]
+        )
         x_min, x_max = min(x_coords), max(x_coords)
         y_min, y_max = min(y_coords), max(y_coords)
 

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -51,7 +51,8 @@ class Register:
     """
 
     def __init__(
-        self, qubits: dict[str, ArrayLike | torch.Tensor] | dict[int, ArrayLike | torch.Tensor]
+        self,
+        qubits: dict[str, ArrayLike | torch.Tensor] | dict[int, ArrayLike | torch.Tensor],
     ) -> None:
         """Default constructor for the Register.
 
@@ -59,16 +60,13 @@ class Register:
             qubits: a dictionary of qubits and respective coordinates {q: (x, y), ...}.
 
         Raises:
-            TypeError: If the qubits argument is not a dictionary.
-            ValueError: If the qubits argument is empty.
-            ValueError: If the coordinate for a qubit is not a tuple, list or
-                numpy or torch array of length 2.
+            TypeError: If `qubits` is not a dictionary.
+            ValueError: If `qubits` is empty.
+            ValueError: If a qubit coordinate cannot be converted to an array of
+                floats, or if the converted coordinate is not a point in 2D.
         """
         if not isinstance(qubits, dict):
-            raise TypeError(
-                "Register must be initialized with a dictionary of "
-                "qubits ids and respective coordinates {q: (x, y), ...}."
-            )
+            raise TypeError("`qubits` must be a dictionary mapping qubit ids to coordinates.")
         if len(qubits) == 0:
             raise ValueError("Register cannot be empty.")
 
@@ -81,15 +79,13 @@ class Register:
                     parsed[key] = np.asarray(val, dtype=float)
             except (ValueError, TypeError) as err:
                 raise ValueError(
-                    f"Coordinate for qubit {key!r} must be castable to an array of floats."
+                    f"Coordinate for qubit {key!r} must be castable to an array of floats, "
+                    f"got {val!r}."
                 ) from err
 
             converted = parsed[key]
             if converted.ndim != 1 or converted.shape[0] != 2:
-                raise ValueError(
-                    f"Coordinate for qubit {key!r} must be a 1D "
-                    f"tuple, list, or array of length 2, got {val!r}."
-                )
+                raise ValueError(f"Coordinate for qubit {key!r} must be a 2D point, got {val!r}.")
 
         self._qubits = parsed
 
@@ -181,7 +177,7 @@ class Register:
 
         x, y = zip(
             *[
-                v.detach().numpy() if (_has_torch and isinstance(v, torch.Tensor)) else v
+                (v.detach().numpy() if (_has_torch and isinstance(v, torch.Tensor)) else v)
                 for v in self.qubits.values()
             ]
         )

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from math import ceil
+from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -9,25 +10,35 @@ from matplotlib.ticker import MultipleLocator
 from qoolqit.graphs import DataGraph, all_node_pairs, distances
 from qoolqit.graphs.utils import radial_distances
 
-__all__ = ["Register"]
-
 
 class Register:
     """The Register in QoolQit, representing a set of qubits with coordinates."""
 
-    def __init__(self, qubits: dict) -> None:
+    def __init__(self, qubits: dict[Any, tuple[float, float]]) -> None:
         """Default constructor for the Register.
 
-        Arguments:
+        Args:
             qubits: a dictionary of qubits and respective coordinates {q: (x, y), ...}.
+
+        Raises:
+            TypeError: If the qubits argument is not a dictionary.
+            ValueError: If the qubits argument is empty.
+            TypeError: If the coordinate for a qubit is not a 2-tuple (x, y).
         """
         if not isinstance(qubits, dict):
             raise TypeError(
                 "Register must be initialized with a dictionary of "
-                "qubits and respective coordinates {q: (x, y), ...}."
+                "qubits ids and respective coordinates {q: (x, y), ...}."
             )
+        if len(qubits) == 0:
+            raise ValueError("Register cannot be empty.")
+        for key, val in qubits.items():
+            if not (isinstance(val, (tuple, list)) and len(val) == 2):
+                raise TypeError(
+                    f"Coordinate for qubit {key!r} must be a 2-tuple (x, y), got {val!r}."
+                )
 
-        self._qubits: dict = qubits
+        self._qubits = qubits
 
     @classmethod
     def from_graph(cls, graph: DataGraph) -> Register:

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -176,9 +176,7 @@ class Register:
 
         x, y = zip(
             *[
-                np.asarray(
-                    v.detach() if (_has_torch and isinstance(v, torch.Tensor)) else v, dtype=float
-                )
+                v.detach().numpy() if (_has_torch and isinstance(v, torch.Tensor)) else v
                 for v in self.qubits.values()
             ]
         )

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -22,10 +22,10 @@ except ImportError:
 
 
 class Register:
-    """The Register in QoolQit, representing a set of qubits with coordinates.
+    """The Register in QoolQit, representing a set of qubit ids with coordinates.
 
     Attributes:
-        qubits: a dictionary of qubits and respective coordinates {q: (x, y),...}.
+        qubits: a dictionary of qubit ids and respective coordinates {q: (x, y),...}.
         qubits_ids: a list of qubit ids.
         n_qubits: the number of qubits in the register.
 
@@ -43,6 +43,11 @@ class Register:
 
         >>> import numpy as np
         >>> reg = Register({"a": np.array([0.0, 0.0]), "b": np.array([1.0, 0.0])})
+
+        Using torch tensors as coordinates:
+
+        >>> import torch
+        >>> reg = Register({"a": torch.tensor([0.0, 0.0]), "b": torch.tensor([1.0, 0.0])})
     """
 
     def __init__(

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from math import ceil
-from typing import Any
 
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.figure import Figure
 from matplotlib.ticker import MultipleLocator
 
@@ -12,9 +12,30 @@ from qoolqit.graphs.utils import radial_distances
 
 
 class Register:
-    """The Register in QoolQit, representing a set of qubits with coordinates."""
+    """The Register in QoolQit, representing a set of qubits with coordinates.
 
-    def __init__(self, qubits: dict[Any, tuple[float, float]]) -> None:
+    Attributes:
+        qubits: a dictionary of qubits and respective coordinates {q: (x, y),...}.
+        qubit_ids: a list of qubit ids.
+        n_qubits: the number of qubits in the register.
+
+    Examples:
+        From a dictionary of qubit ids and coordinates:
+
+        >>> reg = Register({"a": (0.0, 0.0), "b": (1.0, 0.0), "c": (0.0, 1.0)})
+        >>> reg = Register({0: (0.0, 0.0), 1: (1.0, 0.0), 2: (0.0, 1.0)})
+
+        From a list of coordinates (qubit ids are assigned automatically as integers):
+
+        >>> reg = Register.from_coordinates([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)])
+
+        Using numpy arrays as coordinates:
+
+        >>> import numpy as np
+        >>> reg = Register({"a": np.array([0.0, 0.0]), "b": np.array([1.0, 0.0])})
+    """
+
+    def __init__(self, qubits: dict) -> None:
         """Default constructor for the Register.
 
         Args:
@@ -23,7 +44,7 @@ class Register:
         Raises:
             TypeError: If the qubits argument is not a dictionary.
             ValueError: If the qubits argument is empty.
-            TypeError: If the coordinate for a qubit is not a 2-tuple (x, y).
+            ValueError: If the coordinate for a qubit is not a tuple, list or array of length 2.
         """
         if not isinstance(qubits, dict):
             raise TypeError(
@@ -32,13 +53,22 @@ class Register:
             )
         if len(qubits) == 0:
             raise ValueError("Register cannot be empty.")
+
         for key, val in qubits.items():
-            if not (isinstance(val, (tuple, list)) and len(val) == 2):
-                raise TypeError(
-                    f"Coordinate for qubit {key!r} must be a 2-tuple (x, y), got {val!r}."
+            val_array = val
+            if isinstance(val, (tuple, list)):
+                val_array = np.asarray(val, dtype=float)
+            valid = val_array.ndim == 1 and val_array.shape[0] == 2
+            if not valid:
+                raise ValueError(
+                    f"Coordinate for qubit {key!r} must be a tuple, list, or array of length 2, "
+                    f"got {val!r}."
                 )
 
-        self._qubits = qubits
+        self._qubits = {
+            key: (np.asarray(val, dtype=float) if isinstance(val, (tuple, list)) else val)
+            for key, val in qubits.items()
+        }
 
     @classmethod
     def from_graph(cls, graph: DataGraph) -> Register:
@@ -65,15 +95,16 @@ class Register:
         """
         if not isinstance(coords, list):
             raise TypeError(
-                "Register must be initialized with a dictionary of qubit and coordinates."
+                "Register.from_coordinates must be initialized with a list of"
+                " coordinates [(x, y), ...]."
             )
         coords_dict = {i: pos for i, pos in enumerate(coords)}
         return cls(coords_dict)
 
     @property
     def qubits(self) -> dict:
-        """Returns the dictionary of qubits and respective coordinates."""
-        return self._qubits
+        """Returns a copy of the dictionary of qubits and respective coordinates."""
+        return dict(self._qubits)
 
     @property
     def qubits_ids(self) -> list:

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -39,11 +39,11 @@ def _to_array(
     return np.asarray(val, dtype=np.float64)
 
 
-def _norm(x: npt.NDArray[np.float64] | torch.Tensor) -> np.float64 | torch.Tensor:
+def _norm(x: npt.NDArray[np.float64] | torch.Tensor) -> float:
     if _is_torch(x):
-        norm: torch.Tensor = torch.linalg.norm(x)
-        return norm
-    return np.linalg.norm(x)
+        norm = torch.linalg.norm(x)
+    norm = np.linalg.norm(x)
+    return float(norm)
 
 
 def _copy(x: npt.NDArray | torch.Tensor) -> npt.NDArray | torch.Tensor:

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -41,9 +41,8 @@ def _to_array(
 
 def _norm(x: npt.NDArray[np.float64] | torch.Tensor) -> float:
     if _is_torch(x):
-        norm = torch.linalg.norm(x)
-    norm = np.linalg.norm(x)
-    return float(norm)
+        return float(torch.linalg.norm(x))
+    return float(np.linalg.norm(x))
 
 
 def _copy(x: npt.NDArray | torch.Tensor) -> npt.NDArray | torch.Tensor:

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -109,6 +109,9 @@ class Register:
         validated_coords = [self._validate_coord(k, c) for k, c in qubits.items()]
         self._coords = self._stack_coords(validated_coords)
 
+    def __len__(self) -> int:
+        return len(self._qubits_ids)
+
     @staticmethod
     def _validate_coord(
         key: str | int, coord: Sequence[float] | npt.NDArray[np.float64] | torch.Tensor
@@ -192,7 +195,7 @@ class Register:
     @property
     def n_qubits(self) -> int:
         """Number of qubits in the Register."""
-        return len(self.qubits_ids)
+        return len(self)
 
     def distances(self) -> dict:
         """Distance between each qubit pair."""

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -48,17 +48,12 @@ def _norm(x: npt.NDArray[np.float64] | torch.Tensor) -> np.float64 | torch.Tenso
 
 def _copy(x: npt.NDArray | torch.Tensor) -> npt.NDArray | torch.Tensor:
     if _is_torch(x):
-        return x.clone()
+        return x.clone().detach()
     return np.copy(x)
 
 
 class Register:
     """A QoolQit register mapping qubit IDs to 2D coordinates.
-
-    Attributes:
-        qubits: a dictionary of qubit IDs and respective coordinates {q: (x, y),...}.
-        qubits_ids: a list of qubit IDs.
-        n_qubits: the number of qubits in the register.
 
     Examples:
         From a dictionary of qubit IDs and coordinates:
@@ -95,7 +90,7 @@ class Register:
                 Each coordinate must be castable to a numpy or torch array of shape (2,).
 
         Raises:
-            TypeError: If `qubits` is not a dictionary.
+            TypeError: If `qubits` is not a Mapping.
             ValueError: If `qubits` dictionary is empty.
             ValueError: If a qubit coordinate cannot be converted to an array of
                 floats, or if the converted coordinate is not a point in 2D.
@@ -167,12 +162,15 @@ class Register:
     ) -> Register:
         """Initializes a Register from a sequence or array of coordinates.
 
-        Qubit IDs are assigned as integers 0,1,...,N, where N is the number of coordinates.
+        Qubit IDs are assigned as integers 0,1,...,N-1, where N is the number of coordinates.
 
         Args:
             coords: a sequence of 2D coordinates, i.e. [(x, y), ...].
                 Each coordinate must be castable to a numpy or torch array of shape (2,).
                 If `coords` is a numpy array or a torch tensor, it must be 2D and of shape (N, 2).
+
+        Raises:
+            TypeError: If `coords` is a Mapping.
         """
         if isinstance(coords, Mapping):
             raise TypeError(

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Mapping, TypeGuard
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 from matplotlib.axes import Axes
-from numpy.typing import ArrayLike
 
 from qoolqit.graphs import DataGraph, all_node_pairs, distances
-from qoolqit.graphs.utils import radial_distances
 
 if TYPE_CHECKING:
     import torch
+
 
 try:
     import torch
@@ -19,6 +20,30 @@ try:
     _has_torch = True
 except ImportError:
     _has_torch = False
+
+
+def _is_torch(val: Any) -> TypeGuard[torch.Tensor]:
+    return _has_torch and isinstance(val, torch.Tensor)
+
+
+def _to_array(
+    val: Sequence[float] | npt.NDArray[np.float64] | torch.Tensor,
+) -> npt.NDArray[np.float64] | torch.Tensor:
+    """Convert a value to a float array.
+
+    Returns a torch tensor if the value is itself a tensor, otherwise a numpy
+    array.
+    """
+    if _is_torch(val):
+        return val.to(dtype=torch.float64)
+    return np.asarray(val, dtype=np.float64)
+
+
+def _norm(x: npt.NDArray[np.float64] | torch.Tensor) -> np.float64 | torch.Tensor:
+    if _is_torch(x):
+        norm: torch.Tensor = torch.linalg.norm(x)
+        return norm
+    return np.linalg.norm(x)
 
 
 class Register:
@@ -35,7 +60,7 @@ class Register:
         >>> reg = Register({"a": (0.0, 0.0), "b": (1.0, 0.0), "c": (0.0, 1.0)})
         >>> reg = Register({0: (0.0, 0.0), 1: (1.0, 0.0), 2: (0.0, 1.0)})
 
-        From a list of coordinates (qubit IDs are assigned automatically as integers):
+        From a list of coordinates (qubit IDs are assigned automatically as strings "0", "1", ...):
 
         >>> reg = Register.from_coordinates([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)])
 
@@ -52,48 +77,62 @@ class Register:
 
     def __init__(
         self,
-        qubits: dict[str, ArrayLike | torch.Tensor] | dict[int, ArrayLike | torch.Tensor],
+        qubits: (
+            Mapping[str, Sequence[float] | npt.NDArray[np.float64] | torch.Tensor]
+            | Mapping[int, Sequence[float] | npt.NDArray[np.float64] | torch.Tensor]
+        ),
     ) -> None:
         """Default constructor for the Register.
 
         Args:
-            qubits: a dictionary of qubits and respective coordinates {q: (x, y), ...}.
+            qubits: a dictionary of qubits and respective 2D coordinates {q: (x, y), ...}.
+                Each coordinate must be castable to a numpy or torch array of shape (2,).
 
         Raises:
             TypeError: If `qubits` is not a dictionary.
-            ValueError: If `qubits` is empty.
+            ValueError: If `qubits` dictionary is empty.
             ValueError: If a qubit coordinate cannot be converted to an array of
                 floats, or if the converted coordinate is not a point in 2D.
         """
-        if not isinstance(qubits, dict):
+        if not isinstance(qubits, Mapping):
             raise TypeError("`qubits` must be a dictionary mapping qubit ids to coordinates.")
-        if len(qubits) == 0:
+        if not qubits:
             raise ValueError("Register cannot be empty.")
 
-        parsed = {}
-        for key, val in qubits.items():
-            try:
-                if _has_torch and isinstance(val, torch.Tensor):
-                    parsed[key] = torch.asarray(val, dtype=torch.float64)
-                else:
-                    parsed[key] = np.asarray(val, dtype=float)
-            except (ValueError, TypeError) as err:
-                raise ValueError(
-                    f"Coordinate for qubit {key!r} must be castable to an array of floats, "
-                    f"got {val!r}."
-                ) from err
+        self._qubits_ids: tuple[str | int, ...] = tuple(qubits.keys())
+        validated_coords = [self._validate_coord(k, c) for k, c in qubits.items()]
+        self._coords = self._stack_coords(validated_coords)
 
-            converted = parsed[key]
-            if converted.ndim != 1 or converted.shape[0] != 2:
-                raise ValueError(f"Coordinate for qubit {key!r} must be a 2D point, got {val!r}.")
+    @staticmethod
+    def _validate_coord(
+        key: str | int, coord: Sequence[float] | npt.NDArray[np.float64] | torch.Tensor
+    ) -> npt.NDArray[np.float64] | torch.Tensor:
+        try:
+            valid_coord = _to_array(coord)
+        except (ValueError, TypeError) as err:
+            raise ValueError(
+                f"Coordinate for qubit {key!r} must be castable "
+                f"to an array of floats, got {coord!r}."
+            ) from err
 
-        self._qubits = parsed
+        if valid_coord.ndim != 1 or valid_coord.shape[0] != 2:
+            raise ValueError(f"Coordinate for qubit {key!r} must be a 2D point, " f"got {coord!r}.")
+        return valid_coord
+
+    @staticmethod
+    def _stack_coords(
+        coords: Sequence[npt.NDArray[np.float64] | torch.Tensor],
+    ) -> npt.NDArray[np.float64] | torch.Tensor:
+        """Stack already-validated 2D coordinates into a single (n, 2) array."""
+        if any(_is_torch(c) for c in coords):
+            return torch.vstack([torch.asarray(c, dtype=torch.float64) for c in coords])
+        return np.asarray(coords, dtype=np.float64)
 
     @classmethod
     def from_graph(cls, graph: DataGraph) -> Register:
         """Initializes a Register from a graph that has coordinates.
 
-        Arguments:
+        Args:
             graph: a DataGraph instance.
         """
 
@@ -106,38 +145,48 @@ class Register:
         return cls(graph.coords)
 
     @classmethod
-    def from_coordinates(cls, coords: list) -> Register:
-        """Initializes a Register from a list of coordinates.
+    def from_coordinates(
+        cls,
+        coords: (
+            Sequence[Sequence[float] | npt.NDArray[np.float64] | torch.Tensor]
+            | npt.NDArray[np.float64]
+            | torch.Tensor
+        ),
+    ) -> Register:
+        """Initializes a Register from a sequence or array of coordinates.
 
-        Arguments:
-            coords: a list of coordinates [(x, y), ...]
+        Qubit IDs are assigned automatically as strings "0", "1", ...
+
+        Args:
+            coords: a sequence of 2D coordinates, i.e. [(x, y), ...].
+                Each coordinate must be castable to a numpy or torch array of shape (2,).
         """
-        if not isinstance(coords, list):
+        if isinstance(coords, Mapping):
             raise TypeError(
-                "Register.from_coordinates must be initialized with a list of"
-                " coordinates [(x, y), ...]."
+                "Register.from_coordinates expects a sequence of coordinates [(x, y), ...]; "
+                "pass an id-to-coordinate mapping to Register(...) directly."
             )
         coords_dict = {i: pos for i, pos in enumerate(coords)}
         return cls(coords_dict)
 
     @property
     def qubits(self) -> dict:
-        """Returns a copy of the dictionary of qubits and respective coordinates."""
-        return dict(self._qubits)
+        """Returns a dictionary of qubits and respective coordinates."""
+        return {qubit_id: coord for qubit_id, coord in zip(self._qubits_ids, self._coords)}
 
     @property
-    def qubits_ids(self) -> list:
-        """Returns the qubit keys."""
-        return list(self._qubits.keys())
+    def qubits_ids(self) -> tuple[str | int, ...]:
+        """Returns the qubit IDs."""
+        return self._qubits_ids
 
     @property
     def n_qubits(self) -> int:
         """Number of qubits in the Register."""
-        return len(self._qubits)
+        return len(self.qubits_ids)
 
     def distances(self) -> dict:
         """Distance between each qubit pair."""
-        pairs = all_node_pairs(list(self.qubits.keys()))
+        pairs = all_node_pairs(self.qubits_ids)
         return distances(self.qubits, pairs)
 
     def min_distance(self) -> float:
@@ -147,7 +196,7 @@ class Register:
 
     def radial_distances(self) -> dict:
         """Radial distance of each qubit from the origin."""
-        return radial_distances(self.qubits)
+        return {qid: _norm(coord) for qid, coord in zip(self.qubits_ids, self._coords)}
 
     def max_radial_distance(self) -> float:
         """Maximum radial distance between all qubits."""
@@ -175,18 +224,12 @@ class Register:
         marker_radius = marker_size**0.5 / 2  # in points
         annotation_offset = 1.5 * marker_radius  # place label just outside the marker
 
-        x, y = zip(
-            *[
-                (v.detach().numpy() if (_has_torch and isinstance(v, torch.Tensor)) else v)
-                for v in self.qubits.values()
-            ]
-        )
-        ax.scatter(x, y, s=marker_size, color="green")
-
-        for i, qubit_id in enumerate(self.qubits_ids):
+        coords = self._coords.detach().cpu().numpy() if _is_torch(self._coords) else self._coords
+        for xi, yi, qid in zip(coords[:, 0], coords[:, 1], self.qubits_ids):
+            ax.scatter(xi, yi, s=marker_size, color="green")
             ax.annotate(
-                qubit_id,
-                xy=(x[i], y[i]),
+                str(qid),
+                xy=(xi, yi),
                 xytext=(annotation_offset, annotation_offset),
                 textcoords="offset points",
                 ha="center",

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Mapping, TypeGuard
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -95,7 +95,7 @@ class Register:
                 floats, or if the converted coordinate is not a point in 2D.
         """
         if not isinstance(qubits, Mapping):
-            raise TypeError("`qubits` must be a dictionary mapping qubit ids to coordinates.")
+            raise TypeError("`qubits` must be a Mapping of qubit ids to coordinates.")
         if not qubits:
             raise ValueError("Register cannot be empty.")
 
@@ -155,11 +155,12 @@ class Register:
     ) -> Register:
         """Initializes a Register from a sequence or array of coordinates.
 
-        Qubit IDs are assigned automatically as strings "0", "1", ...
+        Qubit IDs are assigned as integers 0,1,...,N, where N is the number of coordinates.
 
         Args:
             coords: a sequence of 2D coordinates, i.e. [(x, y), ...].
                 Each coordinate must be castable to a numpy or torch array of shape (2,).
+                If `coords` is a numpy array or a torch tensor, it must be 2D and of shape (N, 2).
         """
         if isinstance(coords, Mapping):
             raise TypeError(

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -46,6 +46,12 @@ def _norm(x: npt.NDArray[np.float64] | torch.Tensor) -> np.float64 | torch.Tenso
     return np.linalg.norm(x)
 
 
+def _copy(x: npt.NDArray | torch.Tensor) -> npt.NDArray | torch.Tensor:
+    if _is_torch(x):
+        return x.clone()
+    return np.copy(x)
+
+
 class Register:
     """A QoolQit register mapping qubit IDs to 2D coordinates.
 
@@ -116,17 +122,20 @@ class Register:
             ) from err
 
         if valid_coord.ndim != 1 or valid_coord.shape[0] != 2:
-            raise ValueError(f"Coordinate for qubit {key!r} must be a 2D point, " f"got {coord!r}.")
+            raise ValueError(f"Coordinate for qubit {key!r} must be a 2D point, got {coord!r}.")
         return valid_coord
 
     @staticmethod
     def _stack_coords(
         coords: Sequence[npt.NDArray[np.float64] | torch.Tensor],
     ) -> npt.NDArray[np.float64] | torch.Tensor:
-        """Stack already-validated 2D coordinates into a single (n, 2) array."""
+        """Stack already-validated 2D coordinates into a single (n, 2) array.
+
+        If any of the coordinates are torch tensors, the result will also be a torch tensor.
+        """
         if any(_is_torch(c) for c in coords):
-            return torch.vstack([torch.asarray(c, dtype=torch.float64) for c in coords])
-        return np.asarray(coords, dtype=np.float64)
+            return torch.vstack([c if _is_torch(c) else torch.asarray(c) for c in coords])
+        return np.asarray(coords)
 
     @classmethod
     def from_graph(cls, graph: DataGraph) -> Register:
@@ -173,7 +182,7 @@ class Register:
     @property
     def qubits(self) -> dict:
         """Returns a dictionary of qubits and respective coordinates."""
-        return {qubit_id: coord for qubit_id, coord in zip(self._qubits_ids, self._coords)}
+        return {qid: _copy(coord) for qid, coord in zip(self._qubits_ids, self._coords)}
 
     @property
     def qubits_ids(self) -> tuple[str | int, ...]:

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
 import random
+from unittest import mock
 
 import numpy as np
 import pytest
+import torch
 
 from qoolqit.graphs import DataGraph
 from qoolqit.register import Register
+
+
+def test_register_without_torch() -> None:
+    # Remove torch from sys.modules and block the import
+    with mock.patch.dict("sys.modules", {"torch": None}):
+        # Re-import register so the try/except runs again
+        import importlib
+
+        import qoolqit.register as reg_module
+
+        importlib.reload(reg_module)
+        assert reg_module._has_torch is False
 
 
 @pytest.mark.parametrize(
@@ -15,17 +29,26 @@ from qoolqit.register import Register
         {"a": (0, 0), "b": (1, 0), "c": (0, 1)},
         {1: [0, 0], 2: [1, 0]},
         {0: np.array([0.1, 1.2]), 1: np.array([-0.7, -0.4]), 2: np.array([5.0, 0.0])},
+        {
+            "q0": torch.tensor([0.0, 0.0], dtype=torch.float64),
+            "q1": torch.tensor([1.2, 0.0], dtype=torch.float64),
+            "q2": torch.tensor([0.6, 1.04], dtype=torch.float64),
+        },
     ],
 )
-def test_register_init(qubits: dict) -> None:
+def test_init(qubits: dict) -> None:
     reg = Register(qubits)
 
     assert reg.n_qubits == len(qubits)
+    assert reg.qubits_ids == list(qubits.keys())
 
     for k, v in reg.qubits.items():
         assert k in qubits
-        np.testing.assert_allclose(v, qubits[k])
-    assert reg.qubits_ids == list(qubits.keys())
+        if isinstance(v, torch.Tensor):
+            assert torch.allclose(v, qubits[k])
+        else:
+            assert isinstance(v, np.ndarray)
+            np.testing.assert_allclose(v, qubits[k])
 
 
 def test_empty_register() -> None:
@@ -33,7 +56,7 @@ def test_empty_register() -> None:
         Register({})  # type: ignore [call-arg]
 
 
-def test_wrong_qubits_type() -> None:
+def test_init_wrong_qubits_type() -> None:
     with pytest.raises(
         TypeError,
         match="Register must be initialized with a dictionary of ",
@@ -49,12 +72,25 @@ def test_wrong_qubits_type() -> None:
         {7: 32},
     ],
 )
-def test_invalid_coordinates(qubits: dict) -> None:
-    with pytest.raises(ValueError, match="must be a tuple, list, or array of length 2, got"):
+def test_init_invalid_coordinate_shape(qubits: dict) -> None:
+    with pytest.raises(ValueError, match="must be a 1D tuple, list, or array of length 2, got"):
         Register(qubits)
 
 
-def test_wrong_from_coordinates_type() -> None:
+@pytest.mark.parametrize(
+    "qubits",
+    [
+        {"3": np.array(["a", "b"])},
+    ],
+)
+def test_init_invalid_coordinate_type(qubits: dict) -> None:
+    with pytest.raises(
+        ValueError, match="Coordinate for qubit '3' must be castable to an array of floats."
+    ):
+        Register(qubits)
+
+
+def test_from_coordinates_wrong_type() -> None:
     with pytest.raises(TypeError, match="from_coordinates"):
         Register.from_coordinates({"a": (0.0, 0.0)})  # type: ignore [arg-type]
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -9,6 +9,56 @@ from qoolqit.graphs import DataGraph
 from qoolqit.register import Register
 
 
+@pytest.mark.parametrize(
+    "qubits",
+    [
+        {"a": (0, 0), "b": (1, 0), "c": (0, 1)},
+        {1: [0, 0], 2: [1, 0]},
+        {0: np.array([0.1, 1.2]), 1: np.array([-0.7, -0.4]), 2: np.array([5.0, 0.0])},
+    ],
+)
+def test_register_init(qubits: dict) -> None:
+    reg = Register(qubits)
+
+    assert reg.n_qubits == len(qubits)
+
+    for k, v in reg.qubits.items():
+        assert k in qubits
+        np.testing.assert_allclose(v, qubits[k])
+    assert reg.qubits_ids == list(qubits.keys())
+
+
+def test_empty_register() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        Register({})  # type: ignore [call-arg]
+
+
+def test_wrong_qubits_type() -> None:
+    with pytest.raises(
+        TypeError,
+        match="Register must be initialized with a dictionary of ",
+    ):
+        Register("I'm not a dict")  # type: ignore [arg-type]
+
+
+@pytest.mark.parametrize(
+    "qubits",
+    [
+        {0: (1, 2, 3)},
+        {"q0": np.array([1.0, -2.0]), "q1": np.array([[-1.0, -1.0], [-1.0, -1.0]])},
+        {7: 32},
+    ],
+)
+def test_invalid_coordinates(qubits: dict) -> None:
+    with pytest.raises(ValueError, match="must be a tuple, list, or array of length 2, got"):
+        Register(qubits)
+
+
+def test_wrong_from_coordinates_type() -> None:
+    with pytest.raises(TypeError, match="from_coordinates"):
+        Register.from_coordinates({"a": (0.0, 0.0)})  # type: ignore [arg-type]
+
+
 @pytest.mark.parametrize("n_qubits", [3, 4, 10])
 def test_register_from_coordinates(n_qubits: int) -> None:
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -56,14 +56,14 @@ def test_init(qubits: dict) -> None:
 
 
 def test_empty_register() -> None:
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"Register cannot be empty\."):
         Register({})  # type: ignore [call-arg]
 
 
 def test_init_wrong_qubits_type() -> None:
     with pytest.raises(
         TypeError,
-        match="Register must be initialized with a dictionary of ",
+        match=r"`qubits` must be a dictionary mapping qubit ids to coordinates",
     ):
         Register("I'm not a dict")  # type: ignore [arg-type]
 
@@ -77,7 +77,7 @@ def test_init_wrong_qubits_type() -> None:
     ],
 )
 def test_init_invalid_coordinate_shape(qubits: dict) -> None:
-    with pytest.raises(ValueError, match="must be a 1D tuple, list, or array of length 2, got"):
+    with pytest.raises(ValueError, match="must be a 2D point, got"):
         Register(qubits)
 
 
@@ -89,7 +89,8 @@ def test_init_invalid_coordinate_shape(qubits: dict) -> None:
 )
 def test_init_invalid_coordinate_type(qubits: dict) -> None:
     with pytest.raises(
-        ValueError, match="Coordinate for qubit '3' must be castable to an array of floats."
+        ValueError,
+        match=r"Coordinate for qubit '3' must be castable to an array of floats, got",
     ):
         Register(qubits)
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import importlib
 import random
 from unittest import mock
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import torch
@@ -12,15 +14,17 @@ from qoolqit.register import Register
 
 
 def test_register_without_torch() -> None:
+    import qoolqit.register as register_module
+
     # Remove torch from sys.modules and block the import
     with mock.patch.dict("sys.modules", {"torch": None}):
-        # Re-import register so the try/except runs again
-        import importlib
+        # Reload register so the try/except runs again
+        importlib.reload(register_module)
+        assert register_module._has_torch is False
 
-        import qoolqit.register as reg_module
-
-        importlib.reload(reg_module)
-        assert reg_module._has_torch is False
+    # Reload the module to its original state
+    importlib.reload(register_module)
+    assert register_module._has_torch is True
 
 
 @pytest.mark.parametrize(
@@ -144,3 +148,14 @@ def test_radial_distances() -> None:
     radial_dists = register.radial_distances()
     expected_radial_distances = {i: 0.3 * np.sqrt(2) for i in range(3)}
     assert radial_dists == expected_radial_distances
+
+
+def test_draw() -> None:
+    # Just check that no exception is raised
+    reg = Register({"a": (0.0, 0.0), "b": (1.0, 0.0)})
+    reg.draw()
+
+    # to ax
+    fig, ax = plt.subplots()
+    reg.draw(ax=ax, marker_size=50)
+    plt.close(fig)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -64,7 +64,7 @@ def test_empty_register() -> None:
 def test_init_wrong_qubits_type() -> None:
     with pytest.raises(
         TypeError,
-        match=r"`qubits` must be a dictionary mapping qubit ids to coordinates",
+        match=r"`qubits` must be a Mapping of qubit ids to coordinates",
     ):
         Register("I'm not a dict")  # type: ignore [arg-type]
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -30,7 +30,7 @@ def test_register_without_torch() -> None:
 @pytest.mark.parametrize(
     "qubits",
     [
-        {"a": (0, 0), "b": (1, 0), "c": (0, 1)},
+        {"a": (0, 0), "b": (1, 0), "c": [0, 1]},
         {1: [0, 0], 2: [1, 0]},
         {0: np.array([0.1, 1.2]), 1: np.array([-0.7, -0.4]), 2: np.array([5.0, 0.0])},
         {
@@ -38,13 +38,14 @@ def test_register_without_torch() -> None:
             "q1": torch.tensor([1.2, 0.0], dtype=torch.float64),
             "q2": torch.tensor([0.6, 1.04], dtype=torch.float64),
         },
+        {"q0": [torch.tensor(0.0), torch.tensor(1.0)]},
     ],
 )
 def test_init(qubits: dict) -> None:
     reg = Register(qubits)
 
     assert reg.n_qubits == len(qubits)
-    assert reg.qubits_ids == list(qubits.keys())
+    assert reg.qubits_ids == tuple(qubits.keys())
 
     for k, v in reg.qubits.items():
         assert k in qubits
@@ -74,6 +75,7 @@ def test_init_wrong_qubits_type() -> None:
         {0: (1, 2, 3)},
         {"q0": np.array([1.0, -2.0]), "q1": np.array([[-1.0, -1.0], [-1.0, -1.0]])},
         {7: 32},
+        {"q_inf": np.array([np.inf, 0.1]), "q_nan": np.array([[0.1, np.nan]])},
     ],
 )
 def test_init_invalid_coordinate_shape(qubits: dict) -> None:
@@ -102,7 +104,7 @@ def test_from_coordinates_wrong_type() -> None:
 
 @pytest.mark.parametrize("n_qubits", [3, 4, 10])
 def test_register_from_coordinates(n_qubits: int) -> None:
-
+    random.seed(0)  # Ensure reproducibility
     coords = [(random.random(), random.random()) for _ in range(n_qubits)]
     qubits = {i: coords[i] for i in range(n_qubits)}
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -97,6 +97,28 @@ def test_init_invalid_coordinate_type(qubits: dict) -> None:
         Register(qubits)
 
 
+@pytest.mark.parametrize(
+    "qubits",
+    [
+        {"q0": [0.0, 3.0], "q1": [1.0, 0.0]},
+        {"q0": (np.pi, np.pi)},
+        {"q0": np.array([1.0, 0.0])},
+        {1: torch.tensor([0.0, 3.0]), 2: torch.tensor([1.0, 3.0], requires_grad=True)},
+    ],
+)
+def test_qubits_dict_copy(qubits: dict) -> None:
+    register = Register(qubits)
+    qubits1 = register.qubits
+    qubits2 = register.qubits
+
+    for key in qubits:
+        # Check that the qubits are not the same object (to verify that they are distinct copies)
+        assert qubits1[key] is not qubits2[key]
+
+        qubits1[key][0] = 0.01
+        assert qubits1[key][0] != qubits2[key][0]
+
+
 def test_from_coordinates_wrong_type() -> None:
     with pytest.raises(TypeError, match="from_coordinates"):
         Register.from_coordinates({"a": (0.0, 0.0)})  # type: ignore [arg-type]


### PR DESCRIPTION
Resolves #397 

> `Register.__init__` lacks input validation
> 
> **File:** `qoolqit/register.py` — `Register.__init__`
> 
> ## Problems
> 
> 1. **No empty dict guard**: `Register({})` is accepted silently, but `min_distance()`, `max_radial_distance()`, and `draw()` all crash downstream with unhelpful errors.
> 
> 2. **No coordinate value validation**: values are never checked to be 2-tuples of numbers. Inputs like `{"a": "bad"}` or `{"a": (1, 2, 3)}` pass construction and cause cryptic errors later.
> 
> 3. **Missing generic type annotation**: `self._qubits: dict` gives no type information to static checkers. Should be `dict[Any, tuple[float, float]]` or a named alias.
> 

## Changes
- expand register docstrings
- validate input, we accept all cordinates that can be casted to numpy or torch array of shape (2,)

## Next
Next steps are collected in #388 
- validate input and small fixes in Register.from_coordinates()
- deprecate Register.from_graph() 