### PR TITLE
fix typos and rephrase install docs guide

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -1,12 +1,12 @@
-## Install from PyPi
-QoolQit can be installed from PyPi with your favorite pyproject-compatible Python manager.
-On `pip`, for example:
+## Install from PyPI
+QoolQit can be installed from PyPI with your favorite pyproject-compatible Python manager.
+Using `pip`, for example:
 
 ```sh
 pip install qoolqit
 ```
 
-!!! tip "Don't forget to create a virtual environment fist!"
+!!! tip "Don't forget to create a virtual environment first!"
 
 ## Add QoolQit as a dependency
 For usage within a project with a corresponding `pyproject.toml` file, you can add
@@ -20,7 +20,7 @@ dependencies = [
 ```
 
 ## Install from source
-If you wish to install directly from the source, for example, if you are developing code for QoolQit, you can:
+If you are developing code for QoolQit, you can install it directly from source:
 
 1) Clone the [QoolQit GitHub repository](https://github.com/pasqal-io/qoolqit)
 
@@ -28,8 +28,8 @@ If you wish to install directly from the source, for example, if you are develop
   git clone https://github.com/pasqal-io/qoolqit.git
   ```
 
-2) Setup an environment for developing. From your `qoolqit` folder, again install with your favorite environment/package managers.
-  On `venv`/`pip`, for example:
+2) From your `qoolqit` folder, create a virtual environment and install the project in editable mode.
+  Using `venv` and `pip`, for example:
 
   ```sh
   python -m venv .venv

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,3 +1,3 @@
 Here we collect some tutorials:
 
- 1. [Solving basic a QUBO problem](./solving_a_qubo.ipynb)
+ 1. [Solving a QUBO problem](./solving_a_qubo.ipynb)

--- a/docs/tutorials/solving_a_qubo.ipynb
+++ b/docs/tutorials/solving_a_qubo.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Solving a basic QUBO problem\n",
+    "# Solving a QUBO problem\n",
     "\n",
     "A QUBO instance on $N$ variables consists in a symmetric matrix $Q$ of size $N\\times N$. \n",
     "\n",
@@ -458,7 +458,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "qoolqit",
    "language": "python",
    "name": "python3"
   },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ nav:
     - Custom embedders: extended_usage/custom_embedders.ipynb
   - Applications:
     - tutorials/index.md
-    - Solving a QUBO: tutorials/solving_a_qubo.ipynb
+    - Solving a QUBO problem: tutorials/solving_a_qubo.ipynb
   - API reference:
     - qoolqit: reference/qoolqit.md
     - qoolqit.embedding: reference/embedding.md


### PR DESCRIPTION
Resolves #401 

## Changes
- fix typos and rephrase some sentences in` docs/get_started/install.md`
- normalize all titles, heading and index to "Solving a QUBO"

