### PR TITLE
Added circle register classmethod

### DIFF
--- a/docs/tutorials/Critical_state_TFIM.ipynb
+++ b/docs/tutorials/Critical_state_TFIM.ipynb
@@ -89,7 +89,7 @@
     "# emu-sv: exact state-vector backend + observables\n",
     "from emu_sv import Fidelity, StateVector, SVBackend\n",
     "\n",
-    "from qoolqit import AnalogDevice, DataGraph, Drive, InterpolatedWaveform, QuantumProgram, Register\n",
+    "from qoolqit import AnalogDevice, Drive, InterpolatedWaveform, QuantumProgram, Register\n",
     "from qoolqit.execution import CorrelationMatrix, EmulationConfig, LocalEmulator, Occupation"
    ]
   },
@@ -100,7 +100,7 @@
    "source": [
     "## 2. Building the Register\n",
     "\n",
-    "We place $N$ atoms on a circle using `DataGraph.circle`, with the nearest-neighbor spacing normalized to $r=1$. Because the Rydberg interaction decays steeply, $J_{ij} = r_{ij}^{-6}$, next-nearest-neighbor couplings are already tiny compared to nearest-neighbor ones. For $N$ atoms on a circle, this ratio has a simple closed form:\n",
+    "We place $N$ atoms on a circle using `Register.circle`, with the nearest-neighbor spacing normalized to $r=1$. Because the Rydberg interaction decays steeply, $J_{ij} = r_{ij}^{-6}$, next-nearest-neighbor couplings are already tiny compared to nearest-neighbor ones. For $N$ atoms on a circle, this ratio has a simple closed form:\n",
     "\n",
     "$$\n",
     "\\frac{J_{i,i+1}}{J_{i,i+2}} = \\big[2\\cos(\\pi/N)\\big]^{6},\n",
@@ -114,7 +114,7 @@
     "\n",
     "with the periodic identification $\\sigma^z_{N+1}\\equiv \\sigma^z_1$ coming from the circle's closed topology, exactly the nearest-neighbor Ising ring we want, and the natural setting for studying bulk properties of the TFIM.\n",
     "\n",
-    "We can check this directly with `graph.interactions` which returns a dictionary with the value of $J_{ij}$"
+    "We can check this directly with `register.interactions` which returns a dictionary with the value of $J_{ij}$"
    ]
   },
   {
@@ -125,9 +125,9 @@
    "outputs": [],
    "source": [
     "N = 12\n",
-    "graph = DataGraph.circle(N)\n",
+    "register = Register.circle(N)\n",
     "\n",
-    "print(graph.interactions()[(0,1)]/graph.interactions()[(0,2)])"
+    "print(register.interactions()[(0,1)]/register.interactions()[(0,2)])"
    ]
   },
   {
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph.draw(node_color=\"#00C887\")"
+    "register.draw(node_color=\"#00C887\")"
    ]
   },
   {
@@ -178,21 +178,20 @@
     "h = 1.0\n",
     "\n",
     "# Mapping to Rydberg parameters\n",
-    "J_nn = graph.interactions()[(0, 1)]   # nearest-neighbour coupling, = 1 at unit spacing\n",
+    "J_nn = register.interactions()[(0, 1)]   # nearest-neighbour coupling, = 1 at unit spacing\n",
     "OMEGA_R = J_nn / 2                    # = 1/2 at the critical point\n",
     "\n",
     "# Residual local detuning due to interactions with neighbors\n",
     "hz = np.zeros(N)\n",
     "for i in range(N):\n",
     "    hz[i] = 0.5 * sum(\n",
-    "        graph.interactions()[(min(i, j), max(i, j))]\n",
+    "        register.interactions()[(min(i, j), max(i, j))]\n",
     "        for j in range(N) if j != i\n",
     "    )\n",
     "print(f\"Local detuning due to interactions: {hz}\")\n",
     "\n",
     "DELTA = hz[0]\n",
     "\n",
-    "register = Register.from_graph(graph)\n",
     "device = AnalogDevice()\n",
     "\n",
     "print(f\"N = {N} atoms on a ring\")\n",
@@ -410,14 +409,14 @@
     "    ops[site] = op\n",
     "    return reduce(lambda a, b: kron(a, b, format=\"csr\"), ops)  # kron(I2, ..., op, ..., I2)\n",
     "\n",
-    "def build_target_hamiltonian(N, graph, omega, delta):\n",
+    "def build_target_hamiltonian(N, register, omega, delta):\n",
     "    \"\"\"\n",
     "    Build the sparse 2^N x 2^N Rydberg Hamiltonian:\n",
     "        H = sum_j [ (omega/2) sigma^x_j - delta n_j ] + sum_{i<j} J_ij n_i n_j\n",
     "    using Kronecker products of local operators.\n",
     "    Args:\n",
     "        N (int): Number of atoms/sites.\n",
-    "        graph: The register/graph object, providing `graph.interactions()`\n",
+    "        register: The register/graph object, providing `register.interactions()`\n",
     "            as a dict mapping (i, j) with i < j to J_ij.\n",
     "        omega (float): Rabi frequency driving sigma^x on every site.\n",
     "        delta (float): Detuning driving -n_i on every site.\n",
@@ -436,14 +435,14 @@
     "\n",
     "    # Interaction terms: J_ij n_i n_j, summed over all pairs i < j, read\n",
     "    # directly from the graph's interactions dict.\n",
-    "    for (i, j), val in graph.interactions().items():\n",
+    "    for (i, j), val in register.interactions().items():\n",
     "        H = H + val * (n_ops[i] @ n_ops[j])\n",
     "    return H.tocsr()\n",
     "\n",
     "# Diagonalize the target Hamiltonian (only the two lowest eigenpairs are needed)\n",
     "# We use the value of DELTA and OMEGA_R that correspond to the critical point of the TFIM,\n",
     "# The ground state of H_target is the critical state we want to prepare.\n",
-    "H_target = build_target_hamiltonian(N, graph, OMEGA_R, DELTA)\n",
+    "H_target = build_target_hamiltonian(N, register, OMEGA_R, DELTA)\n",
     "evals, evecs = eigsh(H_target, k=2, which=\"SA\")\n",
     "order = np.argsort(evals)\n",
     "evals, evecs = evals[order], evecs[:, order]\n",
@@ -479,7 +478,7 @@
     "sum_n = n_ops[0]\n",
     "for op in n_ops[1:]:\n",
     "    sum_n = sum_n + op\n",
-    "H_base = build_target_hamiltonian(N, graph, OMEGA_R, 0.0)\n",
+    "H_base = build_target_hamiltonian(N, register, OMEGA_R, 0.0)\n",
     "\n",
     "gaps = np.array([\n",
     "    np.diff(np.sort(eigsh(H_base - de * sum_n, k=2, which=\"SA\")[0]))[0]\n",
@@ -792,7 +791,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "qsp-bis (3.14.6)",
+   "display_name": "devqoolqit (3.14.6)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/tutorials/Critical_state_TFIM.ipynb
+++ b/docs/tutorials/Critical_state_TFIM.ipynb
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "register.draw(node_color=\"#00C887\")"
+    "register.draw()"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "networkx>=3.4",
   "numpy>=2",
   "pulser[torch]>=1.8.0",
+  "pytest>=9.1.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
   "networkx>=3.4",
   "numpy>=2",
   "pulser[torch]>=1.8.0",
-  "pytest>=9.1.1",
 ]
 
 [project.optional-dependencies]

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -179,6 +179,25 @@ class Register:
         coords_dict = {i: pos for i, pos in enumerate(coords)}
         return cls(coords_dict)
 
+    @classmethod
+    def circle(cls, n_qubits: int, spacing: float = 1.0) -> Register:
+        """Initializes a Register with qubits arranged in a circle.
+
+        Args:
+            n_qubits: number of qubits to place in the circle.
+            spacing: distance between adjacent qubits. Defaults to 1.0.
+        """
+        if n_qubits < 1:
+            raise ValueError("Number of qubits must be at least 1.")
+        if spacing <= 0:
+            raise ValueError("Spacing must be positive.")
+        if n_qubits == 1:
+            return cls.from_coordinates([(0.0, 0.0)])
+        radius = spacing / (2 * np.sin(np.pi / n_qubits))
+        angles = np.linspace(0, 2 * np.pi, n_qubits, endpoint=False)
+        coords = [(radius * np.cos(a), radius * np.sin(a)) for a in angles]
+        return cls.from_coordinates(coords)
+
     @property
     def qubits(self) -> dict:
         """Returns a dictionary of qubits and respective coordinates."""

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, TypeGuard
 
@@ -180,22 +181,24 @@ class Register:
         return cls(coords_dict)
 
     @classmethod
-    def circle(cls, n_qubits: int, spacing: float = 1.0) -> Register:
+    def circle(cls, n: int, spacing: float = 1.0) -> Register:
         """Initializes a Register with qubits arranged in a circle.
 
         Args:
-            n_qubits: number of qubits to place in the circle.
+            n: number of qubits to place in the circle.
             spacing: distance between adjacent qubits. Defaults to 1.0.
         """
-        if n_qubits < 1:
+        if n < 1:
             raise ValueError("Number of qubits must be at least 1.")
         if spacing <= 0:
             raise ValueError("Spacing must be positive.")
-        if n_qubits == 1:
+        if n == 1:
             return cls.from_coordinates([(0.0, 0.0)])
-        radius = spacing / (2 * np.sin(np.pi / n_qubits))
-        angles = np.linspace(0, 2 * np.pi, n_qubits, endpoint=False)
-        coords = [(radius * np.cos(a), radius * np.sin(a)) for a in angles]
+
+        step = 2.0 * math.pi / n
+        r = spacing / (2.0 * math.sin(math.pi / n))
+        coords = [(math.cos(step * i) * r, math.sin(step * i) * r) for i in range(n)]
+
         return cls.from_coordinates(coords)
 
     @property
@@ -239,16 +242,13 @@ class Register:
     def __repr__(self) -> str:
         return self.__class__.__name__ + f"(n_qubits = {self.n_qubits})"
 
-    def draw(
-        self, ax: Axes | None = None, marker_size: int = 100, node_color: str = "green"
-    ) -> None:
+    def draw(self, ax: Axes | None = None, marker_size: int = 100) -> None:
         """Draw the register.
 
         Args:
             ax: an optional matplotlib Axes instance to draw on.
                 If None, a new Axes will be created.
             marker_size: size of the qubit markers in points squared. Defaults to 100.
-            node_color: color of the qubit markers. Defaults to "green".
         """
         if ax is None:
             _, ax = plt.subplots()
@@ -258,7 +258,7 @@ class Register:
 
         coords = self._coords.detach().cpu().numpy() if _is_torch(self._coords) else self._coords
         for xi, yi, qid in zip(coords[:, 0], coords[:, 1], self.qubits_ids):
-            ax.scatter(xi, yi, s=marker_size, color=node_color)
+            ax.scatter(xi, yi, s=marker_size, color="green")
             ax.annotate(
                 str(qid),
                 xy=(xi, yi),

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -239,13 +239,16 @@ class Register:
     def __repr__(self) -> str:
         return self.__class__.__name__ + f"(n_qubits = {self.n_qubits})"
 
-    def draw(self, ax: Axes | None = None, marker_size: int = 100) -> None:
+    def draw(
+        self, ax: Axes | None = None, marker_size: int = 100, node_color: str = "green"
+    ) -> None:
         """Draw the register.
 
         Args:
             ax: an optional matplotlib Axes instance to draw on.
                 If None, a new Axes will be created.
             marker_size: size of the qubit markers in points squared. Defaults to 100.
+            node_color: color of the qubit markers. Defaults to "green".
         """
         if ax is None:
             _, ax = plt.subplots()
@@ -255,7 +258,7 @@ class Register:
 
         coords = self._coords.detach().cpu().numpy() if _is_torch(self._coords) else self._coords
         for xi, yi, qid in zip(coords[:, 0], coords[:, 1], self.qubits_ids):
-            ax.scatter(xi, yi, s=marker_size, color="green")
+            ax.scatter(xi, yi, s=marker_size, color=node_color)
             ax.annotate(
                 str(qid),
                 xy=(xi, yi),

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -200,4 +200,20 @@ def test_circle() -> None:
     ]
 
     assert register.n_qubits == n_qubits
-    np.testing.assert_allclose(list(register.qubits.values()), expected, atol=1e-8)
+    np.testing.assert_allclose(register._coords, expected, atol=1e-8)
+
+
+def test_invalid_spacing() -> None:
+    with pytest.raises(ValueError, match="Spacing must be positive."):
+        Register.circle(2, spacing=-1)
+
+
+def test_invalid_n_qubits() -> None:
+    with pytest.raises(ValueError, match="Number of qubits must be at least 1."):
+        Register.circle(0, spacing=1.0)
+
+
+@pytest.mark.parametrize("n, spacing", [(2, 1.0), (5, 1.28)])
+def test_circle_min_distance(n: int, spacing: float) -> None:
+    register = Register.circle(n, spacing=spacing)
+    np.testing.assert_allclose(register.min_distance(), spacing, atol=1e-8)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -184,3 +184,22 @@ def test_draw() -> None:
     fig, ax = plt.subplots()
     reg.draw(ax=ax, marker_size=50)
     plt.close(fig)
+
+
+def test_circle() -> None:
+    n_qubits = 4
+    spacing = 0.5
+    register = Register.circle(n_qubits, spacing=spacing)
+
+    radius = spacing / (2 * np.sin(np.pi / n_qubits))
+    expected = {
+        0: (radius, 0.0),
+        1: (0.0, radius),
+        2: (-radius, 0.0),
+        3: (0.0, -radius),
+    }
+
+    assert register.n_qubits == n_qubits
+    for qubit_id, expected_pos in expected.items():
+        np.testing.assert_allclose(register.qubits[qubit_id], expected_pos, atol=1e-7)
+    np.testing.assert_allclose(register.distances()[(0, 1)], spacing)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -187,19 +187,17 @@ def test_draw() -> None:
 
 
 def test_circle() -> None:
-    n_qubits = 4
     spacing = 0.5
+    n_qubits = 4
     register = Register.circle(n_qubits, spacing=spacing)
 
     radius = spacing / (2 * np.sin(np.pi / n_qubits))
-    expected = {
-        0: (radius, 0.0),
-        1: (0.0, radius),
-        2: (-radius, 0.0),
-        3: (0.0, -radius),
-    }
+    expected = [
+        (radius, 0.0),
+        (0.0, radius),
+        (-radius, 0.0),
+        (0.0, -radius),
+    ]
 
     assert register.n_qubits == n_qubits
-    for qubit_id, expected_pos in expected.items():
-        np.testing.assert_allclose(register.qubits[qubit_id], expected_pos, atol=1e-7)
-    np.testing.assert_allclose(register.distances()[(0, 1)], spacing)
+    np.testing.assert_allclose(list(register.qubits.values()), expected, atol=1e-8)


### PR DESCRIPTION
Adds a Register.circle() classmethod that arranges n qubits evenly around a circle with a given spacing between adjacent qubits, computing the radius via the standard formula and validating inputs (n >= 1, spacing > 0).

Includes tests covering exact coordinates, input validation errors, and a min-distance check confirming the generated geometry actually matches the requested spacing.
