### PR TITLE
Add rectangular classmethod to register

### DIFF
--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -201,8 +201,10 @@ class Register:
             for i in range(rows)
             for j in range(cols)
         ]
-        
-    @classmethod    
+
+        return cls.from_coordinates(coords)
+
+    @classmethod
     def circle(cls, n: int, spacing: float = 1.0) -> Register:
         """Initializes a Register with qubits arranged in a circle.
 

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -181,23 +181,26 @@ class Register:
         return cls(coords_dict)
 
     @classmethod
-    def rectangular(cls, rows: int, cols: int, spacing: float = 1.0) -> Register:
+    def rectangular(
+        cls, rows: int, cols: int, row_spacing: float = 1.0, col_spacing: float = 1.0
+    ) -> Register:
         """Initializes a rectangular Register of qubits.
 
         Args:
             rows: number of rows in the rectangle.
             cols: number of columns in the rectangle.
-            spacing: distance between adjacent qubits. Defaults to 1.0.
+            row_spacing: distance between adjacent qubits in the row direction. Defaults to 1.0.
+            col_spacing: distance between adjacent qubits in the column direction. Defaults to 1.0.
         """
         if rows < 1 or cols < 1:
             raise ValueError("Number of rows and columns must be at least 1.")
-        if spacing <= 0:
+        if row_spacing <= 0 or col_spacing <= 0:
             raise ValueError("Spacing must be positive.")
 
-        x_offset = (rows - 1) * spacing / 2.0
-        y_offset = (cols - 1) * spacing / 2.0
+        x_offset = (rows - 1) * row_spacing / 2.0
+        y_offset = (cols - 1) * col_spacing / 2.0
         coords = [
-            (i * spacing - x_offset, j * spacing - y_offset)
+            (i * row_spacing - x_offset, j * col_spacing - y_offset)
             for i in range(rows)
             for j in range(cols)
         ]

--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -179,6 +179,29 @@ class Register:
         coords_dict = {i: pos for i, pos in enumerate(coords)}
         return cls(coords_dict)
 
+    @classmethod
+    def rectangular(cls, rows: int, cols: int, spacing: float = 1.0) -> Register:
+        """Initializes a rectangular Register of qubits.
+
+        Args:
+            rows: number of rows in the rectangle.
+            cols: number of columns in the rectangle.
+            spacing: distance between adjacent qubits. Defaults to 1.0.
+        """
+        if rows < 1 or cols < 1:
+            raise ValueError("Number of rows and columns must be at least 1.")
+        if spacing <= 0:
+            raise ValueError("Spacing must be positive.")
+
+        x_offset = (rows - 1) * spacing / 2.0
+        y_offset = (cols - 1) * spacing / 2.0
+        coords = [
+            (i * spacing - x_offset, j * spacing - y_offset)
+            for i in range(rows)
+            for j in range(cols)
+        ]
+        return cls.from_coordinates(coords)
+
     @property
     def qubits(self) -> dict:
         """Returns a dictionary of qubits and respective coordinates."""

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -187,18 +187,19 @@ def test_draw() -> None:
 
 
 def test_rectangular() -> None:
-    spacing = 0.5
-    register = Register.rectangular(3, 3, spacing=spacing)
+    row_spacing = 0.5
+    col_spacing = 1.5
+    register = Register.rectangular(3, 3, row_spacing=row_spacing, col_spacing=col_spacing)
     expected = [
-        (-spacing, -spacing),
-        (-spacing, 0.0),
-        (-spacing, spacing),
-        (0.0, -spacing),
+        (-row_spacing, -col_spacing),
+        (-row_spacing, 0.0),
+        (-row_spacing, col_spacing),
+        (0.0, -col_spacing),
         (0.0, 0.0),
-        (0.0, spacing),
-        (spacing, -spacing),
-        (spacing, 0.0),
-        (spacing, spacing),
+        (0.0, col_spacing),
+        (row_spacing, -col_spacing),
+        (row_spacing, 0.0),
+        (row_spacing, col_spacing),
     ]
 
     assert register.n_qubits == 9
@@ -208,12 +209,18 @@ def test_rectangular() -> None:
 @pytest.mark.parametrize("rows, cols", [(0, 2), (2, 0), (0, 0), (-1, 2)])
 def test_invalid_rows_cols(rows: int, cols: int) -> None:
     with pytest.raises(ValueError, match="Number of rows and columns must be at least 1."):
-        Register.rectangular(rows, cols, spacing=1.0)
+        Register.rectangular(rows, cols, row_spacing=1.0, col_spacing=1.0)
 
 
-@pytest.mark.parametrize("rows, cols, spacing", [(2, 3, 1.0), (3, 3, 0.75), (1, 5, 1.28)])
-def test_rectangular_min_distance(rows: int, cols: int, spacing: float) -> None:
-    register = Register.rectangular(rows, cols, spacing=spacing)
+@pytest.mark.parametrize(
+    "rows, cols, row_spacing, col_spacing",
+    [(2, 3, 1.0, 1.0), (3, 3, 0.75, 0.75), (1, 5, 1.28, 1.28)],
+)
+def test_rectangular_min_distance(
+    rows: int, cols: int, row_spacing: float, col_spacing: float
+) -> None:
+    register = Register.rectangular(rows, cols, row_spacing=row_spacing, col_spacing=col_spacing)
+    np.testing.assert_allclose(register.min_distance(), min(row_spacing, col_spacing), atol=1e-8)
 
 
 def test_circle() -> None:

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -202,4 +202,16 @@ def test_rectangular() -> None:
     ]
 
     assert register.n_qubits == 9
-    np.testing.assert_allclose(list(register.qubits.values()), expected, atol=1e-8)
+    np.testing.assert_allclose(register._coords, expected, atol=1e-8)
+
+
+@pytest.mark.parametrize("rows, cols", [(0, 2), (2, 0), (0, 0), (-1, 2)])
+def test_invalid_rows_cols(rows: int, cols: int) -> None:
+    with pytest.raises(ValueError, match="Number of rows and columns must be at least 1."):
+        Register.rectangular(rows, cols, spacing=1.0)
+
+
+@pytest.mark.parametrize("rows, cols, spacing", [(2, 3, 1.0), (3, 3, 0.75), (1, 5, 1.28)])
+def test_rectangular_min_distance(rows: int, cols: int, spacing: float) -> None:
+    register = Register.rectangular(rows, cols, spacing=spacing)
+    np.testing.assert_allclose(register.min_distance(), spacing, atol=1e-8)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -214,7 +214,7 @@ def test_invalid_rows_cols(rows: int, cols: int) -> None:
 
 @pytest.mark.parametrize(
     "rows, cols, row_spacing, col_spacing",
-    [(2, 3, 1.0, 1.0), (3, 3, 0.75, 0.75), (1, 5, 1.28, 1.28)],
+    [(2, 3, 1.0, 1.23), (3, 3, 0.75, 2.75), (1, 5, 5.28, 1.28)],
 )
 def test_rectangular_min_distance(
     rows: int, cols: int, row_spacing: float, col_spacing: float

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -184,3 +184,22 @@ def test_draw() -> None:
     fig, ax = plt.subplots()
     reg.draw(ax=ax, marker_size=50)
     plt.close(fig)
+
+
+def test_rectangular() -> None:
+    spacing = 0.5
+    register = Register.rectangular(3, 3, spacing=spacing)
+    expected = [
+        (-spacing, -spacing),
+        (-spacing, 0.0),
+        (-spacing, spacing),
+        (0.0, -spacing),
+        (0.0, 0.0),
+        (0.0, spacing),
+        (spacing, -spacing),
+        (spacing, 0.0),
+        (spacing, spacing),
+    ]
+
+    assert register.n_qubits == 9
+    np.testing.assert_allclose(list(register.qubits.values()), expected, atol=1e-8)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -214,6 +214,8 @@ def test_invalid_rows_cols(rows: int, cols: int) -> None:
 @pytest.mark.parametrize("rows, cols, spacing", [(2, 3, 1.0), (3, 3, 0.75), (1, 5, 1.28)])
 def test_rectangular_min_distance(rows: int, cols: int, spacing: float) -> None:
     register = Register.rectangular(rows, cols, spacing=spacing)
+
+
 def test_circle() -> None:
     spacing = 0.5
     n_qubits = 4


### PR DESCRIPTION
Adds a Register.rectangular() classmethod that arranges rows × cols qubits on a rectangular grid with a given spacing (row_spacing, col_spacing) between adjacent qubits, centering the layout on the origin and validating inputs (rows >= 1, cols >= 1, row_spacing > 0 and col_spacing > 0).

Includes tests covering exact coordinates, input validation errors, and a min-distance check confirming the generated geometry actually matches the requested spacing.