### PR TITLE
Added Line and Square classmethod

### DIFF
--- a/qoolqit/register.py
+++ b/qoolqit/register.py
@@ -208,6 +208,26 @@ class Register:
         return cls.from_coordinates(coords)
 
     @classmethod
+    def square(cls, n: int, spacing: float = 1.0) -> Register:
+        """Initializes a square Register of qubits.
+
+        Args:
+            n: number of qubits along each side of the square.
+            spacing: distance between adjacent qubits. Defaults to 1.0.
+        """
+        return cls.rectangular(n, n, row_spacing=spacing, col_spacing=spacing)
+
+    @classmethod
+    def line(cls, n: int, spacing: float = 1.0) -> Register:
+        """Initializes a Register with qubits arranged in a line.
+
+        Args:
+            n: number of qubits to place in the line.
+            spacing: distance between adjacent qubits. Defaults to 1.0.
+        """
+        return cls.rectangular(n, 1, row_spacing=spacing)
+
+    @classmethod
     def circle(cls, n: int, spacing: float = 1.0) -> Register:
         """Initializes a Register with qubits arranged in a circle.
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -254,3 +254,26 @@ def test_invalid_n_qubits() -> None:
 def test_circle_min_distance(n: int, spacing: float) -> None:
     register = Register.circle(n, spacing=spacing)
     np.testing.assert_allclose(register.min_distance(), spacing, atol=1e-8)
+
+
+def test_square() -> None:
+    spacing = 0.5
+    register = Register.square(2, spacing=spacing)
+    expected = [
+        (-spacing / 2.0, -spacing / 2.0),
+        (-spacing / 2.0, spacing / 2.0),
+        (spacing / 2.0, -spacing / 2.0),
+        (spacing / 2.0, spacing / 2.0),
+    ]
+    assert register.n_qubits == 4
+    np.testing.assert_allclose(register._coords, expected, atol=1e-8)
+
+
+def test_line() -> None:
+    spacing = 0.5
+    n = 4
+    register = Register.line(n, spacing=spacing)
+    offset = (n - 1) * spacing / 2.0
+    expected = [(i * spacing - offset, 0.0) for i in range(n)]
+    assert register.n_qubits == n
+    np.testing.assert_allclose(register._coords, expected, atol=1e-8)


### PR DESCRIPTION
Adds Register.square() and Register.line() convenience classmethods that build on Register.rectangular(). square(n, spacing) creates an n × n grid with equal spacing on both axes, and line(n, spacing) arranges n qubits evenly along a horizontal line with the given spacing between adjacent qubits.

Includes tests verifying exact coordinates for both constructors, confirming square() correctly forwards spacing to both axes and line() places qubits horizontally spaced by spacing.