### PR TITLE
Deprecate top-level `from qoolqit import DataGraph`

### DIFF
--- a/docs/extended_usage/custom_embedders.ipynb
+++ b/docs/extended_usage/custom_embedders.ipynb
@@ -64,8 +64,8 @@
    "source": [
     "from dataclasses import dataclass\n",
     "\n",
-    "from qoolqit.graphs import DataGraph\n",
     "from qoolqit.embedding import EmbedderConfig, GraphToGraphEmbedder\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "\n",
     "def my_embedding_function(graph: DataGraph, param1: float) -> DataGraph:\n",

--- a/docs/extended_usage/custom_embedders.ipynb
+++ b/docs/extended_usage/custom_embedders.ipynb
@@ -64,7 +64,7 @@
    "source": [
     "from dataclasses import dataclass\n",
     "\n",
-    "from qoolqit import DataGraph\n",
+    "from qoolqit.graphs import DataGraph\n",
     "from qoolqit.embedding import EmbedderConfig, GraphToGraphEmbedder\n",
     "\n",
     "\n",
@@ -205,7 +205,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "qoolqit",
    "language": "python",
    "name": "python3"
   },

--- a/docs/fundamentals/compilation/error_handling.ipynb
+++ b/docs/fundamentals/compilation/error_handling.ipynb
@@ -26,7 +26,8 @@
    "outputs": [],
    "source": [
     "# Or use built-in graph patterns\n",
-    "from qoolqit import DataGraph, Register\n",
+    "from qoolqit import Register\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "graph = DataGraph.square(m=2, n=2)\n",
     "register = Register.from_graph(graph)  # 2x2 square lattice\n",
@@ -111,7 +112,8 @@
    "outputs": [],
    "source": [
     "# Or use built-in graph patterns\n",
-    "from qoolqit import DataGraph, Drive, QuantumProgram, Register\n",
+    "from qoolqit import Drive, QuantumProgram, Register\n",
+    "from qoolqit.graphs import DataGraph\n",
     "from qoolqit.waveforms import RampWaveform\n",
     "\n",
     "\n",

--- a/docs/fundamentals/embedding.ipynb
+++ b/docs/fundamentals/embedding.ipynb
@@ -249,7 +249,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qoolqit import DataGraph\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "graph_1 = DataGraph.random_er(n = 7, p = 0.3, seed = 3)\n",
     "embedded_graph_1 = embedder.embed(graph_1)\n",

--- a/docs/fundamentals/graphs.ipynb
+++ b/docs/fundamentals/graphs.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qoolqit import DataGraph\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "edges = [(0, 1), (1, 2), (2, 3), (3, 0)]\n",
     "graph = DataGraph(edges)"
@@ -299,7 +299,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qoolqit import DataGraph\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "coords = [(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (0.0, -1.0)]\n",
     "\n",

--- a/docs/get_started/programming_with_qoolqit.ipynb
+++ b/docs/get_started/programming_with_qoolqit.ipynb
@@ -54,7 +54,7 @@
     "])\n",
     "\n",
     "# Or use built-in graph patterns\n",
-    "from qoolqit import DataGraph\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "graph = DataGraph.square(m=2, n=2)\n",
     "register = Register.from_graph(graph)  # 2x2 square lattice\n",
@@ -76,7 +76,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qoolqit import DataGraph, Register\n",
+    "from qoolqit import Register\n",
+    "from qoolqit.graphs import DataGraph\n",
     "from qoolqit.embedding import SpringLayoutEmbedder\n",
     "\n",
     "graph = DataGraph.random_er(n=5, p=0.3, seed=3)\n",

--- a/docs/get_started/programming_with_qoolqit.ipynb
+++ b/docs/get_started/programming_with_qoolqit.ipynb
@@ -77,8 +77,8 @@
    "outputs": [],
    "source": [
     "from qoolqit import Register\n",
-    "from qoolqit.graphs import DataGraph\n",
     "from qoolqit.embedding import SpringLayoutEmbedder\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "graph = DataGraph.random_er(n=5, p=0.3, seed=3)\n",
     "embedded_graph = SpringLayoutEmbedder().embed(graph)\n",

--- a/docs/tutorials/Solving_a_MWIS.ipynb
+++ b/docs/tutorials/Solving_a_MWIS.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from qoolqit import DataGraph\n",
+    "from qoolqit.graphs import DataGraph\n",
     "\n",
     "# Build the graph from its edges, then attach a weight to each node.\n",
     "graph = DataGraph([(0, 1), (0, 2), (0, 3), (2, 3)])\n",

--- a/qoolqit/__init__.py
+++ b/qoolqit/__init__.py
@@ -16,7 +16,6 @@ from qoolqit.devices import (
 )
 from qoolqit.drive import Drive
 from qoolqit.execution.sequence_compiler import SequenceCompiler
-from qoolqit.graphs import DataGraph
 from qoolqit.program import QuantumProgram
 from qoolqit.register import Register
 from qoolqit.waveforms import (
@@ -29,7 +28,6 @@ from qoolqit.waveforms import (
 )
 
 __all__ = [
-    "DataGraph",
     "BlackmanWaveform",
     "ConstantWaveform",
     "DelayWaveform",
@@ -83,4 +81,14 @@ def __getattr__(name: str) -> type:
             stacklevel=2,
         )
         return new_name
+    if name == "DataGraph":
+        from qoolqit.graphs import DataGraph
+
+        warnings.warn(
+            "Importing `DataGraph` directly from `qoolqit` is deprecated and will be "
+            "removed in v1.4. Use `from qoolqit.graphs import DataGraph` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return DataGraph
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/qoolqit/__init__.py
+++ b/qoolqit/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name: str) -> type:
     if name in _DEPRECATED_WAVEFORM_ALIASES:
         new_name = _DEPRECATED_WAVEFORM_ALIASES[name]
         warnings.warn(
-            f"{name} is deprecated and will be removed in v1.4. "
+            f"{name} is deprecated and will be removed in v2. "
             f"Use the equivalent {new_name.__name__} instead.",
             DeprecationWarning,
             stacklevel=2,
@@ -86,7 +86,7 @@ def __getattr__(name: str) -> type:
 
         warnings.warn(
             "Importing `DataGraph` directly from `qoolqit` is deprecated and will be "
-            "removed in v1.4. Use `from qoolqit.graphs import DataGraph` instead.",
+            "removed in v2. Use `from qoolqit.graphs import DataGraph` instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -5,10 +5,11 @@ from typing import Callable
 import pytest
 from pulser.sequence import Sequence as PulserSequence
 
-from qoolqit import AnalogDevice, DataGraph, DigitalAnalogDevice, MockDevice
+from qoolqit import AnalogDevice, DigitalAnalogDevice, MockDevice
 from qoolqit.devices import Device
 from qoolqit.drive import DetuningMapModulator, Drive
 from qoolqit.exceptions import CompilationError
+from qoolqit.graphs import DataGraph
 from qoolqit.program import QuantumProgram
 from qoolqit.register import Register
 from qoolqit.waveforms import ConstantWaveform


### PR DESCRIPTION
## Summary
- Deprecates importing `DataGraph` from the package root; accessing `qoolqit.DataGraph` now emits a `DeprecationWarning` pointing to `from qoolqit.graphs import DataGraph`, following the same `__getattr__` shim already used for the waveform aliases.
- Updates internal test and doc-notebook imports to use `from qoolqit.graphs import DataGraph`.

Closes #423

## Test plan
- [x] `pytest tests` — 483 passed
- [x] `mypy qoolqit/__init__.py` — clean
- [x] Manually verified `qoolqit.DataGraph` still resolves to `qoolqit.graphs.DataGraph` and warns
- [x] Notebooks re-validated as JSON after import edits