### PR TITLE
add interaction matrix to DataGraph

### DIFF
--- a/qoolqit/graphs/base_graph.py
+++ b/qoolqit/graphs/base_graph.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import networkx as nx
+import numpy as np
 from matplotlib.axes import Axes
 
 from .utils import (
@@ -245,6 +246,25 @@ class BaseGraph(nx.Graph):
     def interactions(self) -> dict:
         """Rydberg model interaction 1/r^6 between pair of nodes."""
         return {p: 1.0 / (r**6) for p, r in self.distances().items()}
+
+    def interaction_matrix(self) -> np.ndarray:
+        """Rydberg model interaction 1/r^6 between pairs of nodes, as a matrix.
+
+        Node ordering follows `self.nodes` insertion order.
+        The diagonal is 0, since there is no self-interaction.
+
+        Returns:
+            Symmetric N x N matrix of dtype float64, where N is the number of nodes.
+        """
+        index = {node: i for i, node in enumerate(self.nodes)}
+        n_nodes = len(index)
+        matrix = np.zeros((n_nodes, n_nodes), dtype=np.float64)
+
+        for (u, v), interaction in self.interactions().items():
+            i, j = index[u], index[v]
+            matrix[i, j] = matrix[j, i] = interaction
+
+        return matrix
 
     def min_distance(self, connected: bool | None = None) -> float:
         """Returns the minimum distance in the graph.

--- a/tests/test_graphs/test_base_graph.py
+++ b/tests/test_graphs/test_base_graph.py
@@ -39,6 +39,14 @@ def test_basegraph_init(n_nodes: int) -> None:
     with pytest.raises(AttributeError):
         graph.max_distance()
 
+    no_coords_match = "Trying to compute distances for a graph without coordinates."
+
+    with pytest.raises(AttributeError, match=no_coords_match):
+        graph.interactions()
+
+    with pytest.raises(AttributeError, match=no_coords_match):
+        graph.interaction_matrix()
+
     with pytest.raises(AttributeError):
         graph.is_ud_graph()
 
@@ -59,6 +67,41 @@ def test_basegraph_init(n_nodes: int) -> None:
     assert len(graph.ud_edges(radius=0.0)) == 0
     assert len(graph.ud_edges(radius=1.0)) >= 1
     assert len(graph.ud_edges(radius=10.0 * scale)) == max_n_edges
+
+
+@pytest.mark.parametrize("n_nodes", [5, 10, 50])
+def test_basegraph_interaction_matrix(n_nodes: int) -> None:
+
+    n_edges = 2 * n_nodes
+
+    edge_list = random_edge_list(range(n_nodes), n_edges)
+    graph = BaseGraph(edge_list)
+
+    # Because a random edge list might leave one disconnected one
+    actual_n_nodes = len(graph.nodes)
+
+    no_coords_match = "Trying to compute distances for a graph without coordinates."
+
+    with pytest.raises(AttributeError, match=no_coords_match):
+        graph.interactions()
+
+    with pytest.raises(AttributeError, match=no_coords_match):
+        graph.interaction_matrix()
+
+    scale = ((actual_n_nodes**0.5) ** 0.5) / 2
+    coords = random_coords(actual_n_nodes, scale)
+    graph.coords = {i: pos for i, pos in zip(graph.nodes, coords)}
+
+    interaction_matrix = graph.interaction_matrix()
+    index = {node: i for i, node in enumerate(graph.nodes)}
+
+    assert interaction_matrix.shape == (actual_n_nodes, actual_n_nodes)
+    assert np.allclose(interaction_matrix, interaction_matrix.T)
+    assert np.allclose(np.diag(interaction_matrix), 0.0)
+
+    for (u, v), interaction in graph.interactions().items():
+        assert np.isclose(interaction_matrix[index[u], index[v]], interaction)
+        assert np.isclose(interaction_matrix[index[v], index[u]], interaction)
 
 
 @pytest.mark.parametrize("n_nodes", [5, 10, 50])

--- a/tests/test_graphs/test_base_graph.py
+++ b/tests/test_graphs/test_base_graph.py
@@ -5,6 +5,7 @@ from typing import Any
 import networkx as nx
 import numpy as np
 import pytest
+from scipy.spatial.distance import pdist, squareform
 from torch_geometric.data import Data
 
 from qoolqit.graphs import BaseGraph, random_coords, random_edge_list
@@ -69,39 +70,26 @@ def test_basegraph_init(n_nodes: int) -> None:
     assert len(graph.ud_edges(radius=10.0 * scale)) == max_n_edges
 
 
-@pytest.mark.parametrize("n_nodes", [5, 10, 50])
-def test_basegraph_interaction_matrix(n_nodes: int) -> None:
+@pytest.mark.parametrize("n_nodes", [3, 8, 13])
+def test_basegraph_interactions(n_nodes: int) -> None:
 
-    n_edges = 2 * n_nodes
+    rng = np.random.default_rng(0)
+    coords_array = rng.uniform(-1, 1, size=(n_nodes, 2))
+    graph = BaseGraph.from_coordinates([c for c in coords_array])
 
-    edge_list = random_edge_list(range(n_nodes), n_edges)
-    graph = BaseGraph(edge_list)
+    expected_interactions = {
+        (i, j): np.linalg.norm(coords_array[i] - coords_array[j]) ** (-6)
+        for i in range(n_nodes)
+        for j in range(i + 1, n_nodes)
+    }
+    expected_interaction_matrix = squareform(1 / pdist(coords_array) ** 6)
 
-    # Because a random edge list might leave one disconnected one
-    actual_n_nodes = len(graph.nodes)
+    interactions = graph.interactions()
+    assert isinstance(interactions, dict)
+    for (u, v), interaction in expected_interactions.items():
+        np.testing.assert_allclose(interactions[(u, v)], interaction, atol=1e-8)
 
-    no_coords_match = "Trying to compute distances for a graph without coordinates."
-
-    with pytest.raises(AttributeError, match=no_coords_match):
-        graph.interactions()
-
-    with pytest.raises(AttributeError, match=no_coords_match):
-        graph.interaction_matrix()
-
-    scale = ((actual_n_nodes**0.5) ** 0.5) / 2
-    coords = random_coords(actual_n_nodes, scale)
-    graph.coords = {i: pos for i, pos in zip(graph.nodes, coords)}
-
-    interaction_matrix = graph.interaction_matrix()
-    index = {node: i for i, node in enumerate(graph.nodes)}
-
-    assert interaction_matrix.shape == (actual_n_nodes, actual_n_nodes)
-    assert np.allclose(interaction_matrix, interaction_matrix.T)
-    assert np.allclose(np.diag(interaction_matrix), 0.0)
-
-    for (u, v), interaction in graph.interactions().items():
-        assert np.isclose(interaction_matrix[index[u], index[v]], interaction)
-        assert np.isclose(interaction_matrix[index[v], index[u]], interaction)
+    np.testing.assert_allclose(graph.interaction_matrix(), expected_interaction_matrix, atol=1e-8)
 
 
 @pytest.mark.parametrize("n_nodes", [5, 10, 50])


### PR DESCRIPTION
## Changes
- Adds `interaction_matrix()` to `BaseGraph` (inherited by `DataGraph`), returning the dense Rydberg interaction matrix (`1/r_ij**6`) as a symmetric `(N, N)` array with a zero diagonal. Node ordering follows `self.nodes` insertion order, consistent with `to_matrix`. 
- Raises `AttributeError` if the graph has no coordinates, same as `interactions()`/`distances()`.
- test

Closes #432.

## Test plan
- Added tests for some random coordinates, building the matrix explicitly.