### PR TITLE
Bump pulser to 1.9.0 and pasqal-cloud to 0.23

### DIFF
--- a/docs/fundamentals/compilation/device_and_compilation.ipynb
+++ b/docs/fundamentals/compilation/device_and_compilation.ipynb
@@ -72,11 +72,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pulser_pasqal import PasqalCloud\n",
+    "from pasqal_cloud import PasqalCloudConnection\n",
     "\n",
     "from qoolqit import Device\n",
     "\n",
-    "connection = PasqalCloud()\n",
+    "connection = PasqalCloudConnection()\n",
     "print(connection.fetch_available_devices())\n",
     "\n",
     "# fetch QoolQit device\n",

--- a/docs/fundamentals/execution/execution.ipynb
+++ b/docs/fundamentals/execution/execution.ipynb
@@ -299,7 +299,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `RemoteEmulator` supports the equivalent remote version of the above-mentioned backends, respectively `RemoteEmuFreeBackend` (default), `EmuSVBackend` and `EmuMPSBackend`.\n",
+    "The `RemoteEmulator` supports the equivalent remote version of the above-mentioned backends, respectively `RemoteEmuFreeBackend` (default), `RemoteSVBackend` and `RemoteMPSBackend`.\n",
     "Depending on your provider, however, some emulator backend might not be available to use.\n",
     "\n",
     "As before, also `RemoteEmulator` can be instantiated with:\n",

--- a/docs/fundamentals/execution/execution.ipynb
+++ b/docs/fundamentals/execution/execution.ipynb
@@ -303,7 +303,7 @@
     "Depending on your provider, however, some emulator backend might not be available to use.\n",
     "\n",
     "As before, also `RemoteEmulator` can be instantiated with:\n",
-    "- `backend_type`: remote counterpart of local backends, namely `RemoteEmuFreeBackend` (default), `EmuSVBackend`, `EmuMPSBackend`.\n",
+    "- `backend_type`: remote counterpart of local backends, namely `RemoteEmuFreeBackend` (default), `RemoteSVBackend`, `RemoteMPSBackend`.\n",
     "- `emulation_config`: same as local emulators. See [Emulation configuration](#emulation-configuration).\n",
     "- `num_shots`: same as local emulators.\n",
     "\n",

--- a/docs/fundamentals/execution/execution.ipynb
+++ b/docs/fundamentals/execution/execution.ipynb
@@ -267,14 +267,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pulser_pasqal import PasqalCloud\n",
+    "from pasqal_cloud import PasqalCloudConnection\n",
     "\n",
-    "# connection = PasqalCloud(\n",
+    "# connection = PasqalCloudConnection(\n",
     "#     username=USERNAME,  # Your username or email address for the Pasqal Cloud Platform\n",
     "#     password=PASSWORD,  # The password for your Pasqal Cloud Platform account\n",
     "#     project_id=PROJECT_ID,  # The ID of the project associated to your account\n",
     "# )\n",
-    "connection = PasqalCloud()"
+    "connection = PasqalCloudConnection()"
    ]
   },
   {
@@ -299,15 +299,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `RemoteEmulator` supports the equivalent remote version of the above-mentioned backends, respectively `EmuFreeBackendV2` (default), `EmuSVBackend` and `EmuMPSBackend`.\n",
+    "The `RemoteEmulator` supports the equivalent remote version of the above-mentioned backends, respectively `RemoteEmuFreeBackend` (default), `EmuSVBackend` and `EmuMPSBackend`.\n",
     "Depending on your provider, however, some emulator backend might not be available to use.\n",
     "\n",
     "As before, also `RemoteEmulator` can be instantiated with:\n",
-    "- `backend_type`: remote counterpart of local backends, namely `EmuFreeBackendV2` (default), `EmuSVBackend`, `EmuMPSBackend`.\n",
+    "- `backend_type`: remote counterpart of local backends, namely `RemoteEmuFreeBackend` (default), `EmuSVBackend`, `EmuMPSBackend`.\n",
     "- `emulation_config`: same as local emulators. See [Emulation configuration](#emulation-configuration).\n",
     "- `num_shots`: same as local emulators.\n",
     "\n",
-    "As an example, below, we specify to emulate the program with the `EmuFreeBackendV2` and a custom `EmulationConfig`:"
+    "As an example, below, we specify to emulate the program with the `RemoteEmuFreeBackend` and a custom `EmulationConfig`:"
    ]
   },
   {
@@ -330,7 +330,7 @@
     "\n",
     "# initialize the remote emulator with the custom configuration and num_shots\n",
     "remote_emulator = RemoteEmulator(\n",
-    "    backend_type=BackendType.EmuFreeBackendV2,\n",
+    "    backend_type=BackendType.RemoteEmuFreeBackend,\n",
     "    connection=connection,\n",
     "    emulation_config=emulation_config,\n",
     "    num_shots=1000,\n",

--- a/docs/tutorials/solving_a_qubo.ipynb
+++ b/docs/tutorials/solving_a_qubo.ipynb
@@ -265,7 +265,7 @@
     "Before executing the quantum program, we need to compile it to a specific device real quantum device.\n",
     "\n",
     "### Selecting a device\n",
-    "We pick the `FRESNEL`, a real Pasqal quantum device, whose specs can be fetched remotely from the `PasqalCloud` interface.\n",
+    "We pick the `FRESNEL`, a real Pasqal quantum device, whose specs can be fetched remotely from the `PasqalCloudConnection` interface.\n",
     "Then, we compile the program, and run it for a set number shots. "
    ]
   },
@@ -276,11 +276,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pulser_pasqal import PasqalCloud\n",
+    "from pasqal_cloud import PasqalCloudConnection\n",
     "\n",
     "from qoolqit import Device\n",
     "\n",
-    "fresnel_device = Device.from_connection(connection=PasqalCloud(), name=\"FRESNEL\")"
+    "fresnel_device = Device.from_connection(connection=PasqalCloudConnection(), name=\"FRESNEL\")"
    ]
   },
   {
@@ -472,7 +472,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.6"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ plugins:
           backlinks: tree
           docstring_options:
             ignore_init_summary: true
+            warnings: false
           docstring_section_style: list
           filters: public
           heading_level: 2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,6 @@ plugins:
           backlinks: tree
           docstring_options:
             ignore_init_summary: true
-            warn_missing_types: false  # griffe: pulser/backend/results.py:287: No type or annotation for parameter 'observable_tag'
           docstring_section_style: list
           filters: public
           heading_level: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
   "networkx>=3.4",
   "numpy>=2",
-  "pulser[torch]>=1.8.0",
+  "pulser[torch]>=1.9.0",
 ]
 
 [project.optional-dependencies]

--- a/qoolqit/devices/device.py
+++ b/qoolqit/devices/device.py
@@ -28,11 +28,11 @@ class Device:
 
         From remote Pulser device:
         ```python
-        from pulser_pasqal import PasqalCloud
+        from pasqal_cloud import PasqalCloudConnection
         from qoolqit import Device
 
         # Fetch the remote device from the connection
-        connection = PasqalCloud()
+        connection = PasqalCloudConnection()
         pulser_fresnel_device = connection.fetch_available_devices()["FRESNEL"]
 
         # Wrap a Pulser device object into a QoolQit Device
@@ -209,8 +209,8 @@ class Device:
 
         Example:
         ```python
-        from pulser_pasqal import PasqalCloud
-        fresnel_device = Device.from_connection(connection=PasqalCloud(), name="FRESNEL")
+        from pasqal_cloud import PasqalCloudConnection
+        fresnel_device = Device.from_connection(connection=PasqalCloudConnection(), name="FRESNEL")
         ```
         """
         available_remote_devices = connection.fetch_available_devices()

--- a/qoolqit/execution/backends.py
+++ b/qoolqit/execution/backends.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+from pasqal_cloud.backends import RemoteEmuFreeBackend, RemoteEmulatorBackend
 from pulser.backend import BackendConfig, BitStrings, Results
 from pulser.backend.abc import EmulatorBackend
 from pulser.backend.config import EmulationConfig
 from pulser.backend.qpu import QPUBackend
 from pulser.backend.remote import RemoteConnection
-from pulser_pasqal.backends import EmuFreeBackendV2, RemoteEmulatorBackend
 from pulser_simulation import QutipBackendV2
 
 from qoolqit.execution import job
@@ -131,17 +131,19 @@ class RemoteEmulator(PulserEmulatorBackend, PulserRemoteBackend):
 
     Args:
         backend_type (type): backend type. Must be a subtype of
-            `pulser_pasqal.backends.RemoteEmulatorBackend`.
+            `pasqal_cloud.backends.RemoteEmulatorBackend`.
         connection (RemoteConnection): connection to execute the program on remote backends.
         emulation_config (EmulationConfig): optional configuration object emulators.
         num_shots (int): number of bitstring samples to collect from the final quantum state.
 
     Examples:
         ```python
-        from pulser_pasqal import PasqalCloud
+        from pasqal_cloud import PasqalCloudConnection
         from qoolqit.execution import RemoteEmulator, BackendType
-        connection = PasqalCloud(username=..., password=..., project_id=...)
-        backend = RemoteEmulator(backend_type=BackendType.EmuFreeBackendV2, connection=connection)
+        connection = PasqalCloudConnection(username=..., password=..., project_id=...)
+        backend = RemoteEmulator(
+            backend_type=BackendType.RemoteEmuFreeBackend, connection=connection
+        )
         ```
         then
         ```python
@@ -156,7 +158,7 @@ class RemoteEmulator(PulserEmulatorBackend, PulserRemoteBackend):
     def __init__(
         self,
         *,
-        backend_type: type[RemoteEmulatorBackend] = EmuFreeBackendV2,
+        backend_type: type[RemoteEmulatorBackend] = RemoteEmuFreeBackend,
         connection: RemoteConnection,
         emulation_config: EmulationConfig | None = None,
         num_shots: int | None = None,
@@ -204,10 +206,10 @@ class QPU(PulserRemoteBackend):
     Examples:
         Using Pasqal Cloud:
         ```python
-        from pulser_pasqal import PasqalCloud
+        from pasqal_cloud import PasqalCloudConnection
         from qoolqit.execution import QPU
 
-        connection = PasqalCloud(
+        connection = PasqalCloudConnection(
             username="your_username",
             password="your_password",
             project_id="your_project_id"

--- a/tests/test_compilation/test_max_energy.py
+++ b/tests/test_compilation/test_max_energy.py
@@ -149,5 +149,7 @@ class TestMaxEnergyCompilerProfile:
             seq_sample = sample(program.compiled_sequence)
             seq_max_amp = max(seq_sample.channel_samples["rydberg"].amp)
 
-            np.testing.assert_allclose(seq_max_amp, device._max_amp, atol=1e-8)
+            # atol loosened because pulser 1.9 changed InterpolatedWaveform's sampling,
+            # so the discretized peak no longer matches the analytical max as tightly.
+            np.testing.assert_allclose(seq_max_amp, device._max_amp, atol=1e-5)
             assert seq_max_amp < device._max_amp

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -4,7 +4,7 @@ import random
 
 import numpy as np
 import pytest
-from pulser_pasqal import PasqalCloud
+from pasqal_cloud import PasqalCloudConnection
 
 from qoolqit import (
     AnalogDevice,
@@ -155,7 +155,7 @@ def test_device_properties() -> None:
 
 
 def test_device_from_connection() -> None:
-    fresnel_device = Device.from_connection(PasqalCloud(), "FRESNEL")
+    fresnel_device = Device.from_connection(PasqalCloudConnection(), "FRESNEL")
     assert fresnel_device.name == "FRESNEL"
 
     expected_fresnel_specs = {
@@ -174,4 +174,4 @@ def test_device_from_connection_not_available() -> None:
     with pytest.raises(
         ValueError, match="Device HELLO_WORLD is not available through the provided connection."
     ):
-        Device.from_connection(connection=PasqalCloud(), name="HELLO_WORLD")
+        Device.from_connection(connection=PasqalCloudConnection(), name="HELLO_WORLD")

--- a/tests/test_execution/test_backends.py
+++ b/tests/test_execution/test_backends.py
@@ -5,12 +5,12 @@ from collections.abc import Sequence
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
+from pasqal_cloud.backends import RemoteEmulatorBackend
 from pulser.backend import BitStrings, EmulationConfig, EmulatorBackend, Results
 from pulser.backend.config import BackendConfig
 from pulser.backend.qpu import QPUBackend
 from pulser.backend.remote import JobParams, RemoteConnection, RemoteResults
 from pulser.sequence import Sequence as PulserSequence
-from pulser_pasqal.backends import RemoteEmulatorBackend
 
 from qoolqit.execution import QPU, LocalEmulator, RemoteEmulator
 from qoolqit.program import QuantumProgram


### PR DESCRIPTION
Bump pulser to 1.9.0 and pasqal-cloud to 0.23

## Changes
- `pyproject.toml`: bumped `pulser[torch]>=1.9.0`; `pasqal-cloud` isn't a direct dependency — it comes transitively via pulser, and pulser 1.9.0 pulls in `pasqal-cloud>=0.23` on its own.
- **pasqal_cloud >= 0.23**: pulser 1.9 dropped the separate `pulser_pasqal` package — `PasqalCloud` and the remote backend classes (`RemoteEmulatorBackend`, `EmuFreeBackendV2` → renamed `RemoteEmuFreeBackend`) moved into `pasqal_cloud` (with `PasqalCloud` renamed to `PasqalCloudConnection`). Updated imports/usages in `qoolqit/execution/backends.py`, `qoolqit/devices/device.py`, `tests/test_devices.py`, `tests/test_execution/test_backends.py`, and 3 doc notebooks.
- **Test fix**: `InterpolatedWaveform` sampling changed slightly in pulser 1.9, so `tests/test_compilation/test_max_energy.py` needed a loosened tolerance (`atol=1e-5` instead of `1e-8`) since the discretized peak no longer matches the analytical max as tightly — noted as such in the comment.

- **disable mkdocstrings warnings**
     I don't see a clear way to ignore specific package warnings when building docs in strict mode `mkdocs build --strict`.
     Failing on 
     ```
     WARNING -  griffe: /opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/pulser/backend/default_observables.py:452: Confusing indentation for continuation line 14 in docstring, should be 4 * 2 = 8 spaces, not 5
     ```
    It is a nice check but we cannot have the full pipeline to fail because of a typo in an external package.