### PR TITLE
Fix int-truncation bug in Waveform array sampling

### DIFF
--- a/qoolqit/waveforms/base_waveforms.py
+++ b/qoolqit/waveforms/base_waveforms.py
@@ -53,7 +53,7 @@ class Waveform(ABC):
                 f"Extra arguments in {type(self).__name__} need to be passed as keyword arguments"
             )
 
-        self._duration = duration
+        self._duration = float(duration)
         self._params_dict = kwargs
 
         for key, value in kwargs.items():
@@ -99,7 +99,7 @@ class Waveform(ABC):
         return self._params_dict
 
     def _single_call(self, t: float) -> float:
-        return 0.0 if (t < 0.0 or t > self.duration) else self.function(t)
+        return 0.0 if (t < 0.0 or t > self.duration) else float(self.function(t))
 
     @overload
     def __call__(self, t: float) -> float: ...
@@ -109,7 +109,7 @@ class Waveform(ABC):
 
     def __call__(self, t: float | list[float] | np.ndarray) -> float | list[float] | np.ndarray:
         if isinstance(t, np.ndarray):
-            return np.vectorize(self._single_call)(t)
+            return np.vectorize(self._single_call, otypes=[float])(t)
         if isinstance(t, list):
             return [self._single_call(ti) for ti in t]
         return self._single_call(t)

--- a/qoolqit/waveforms/waveforms.py
+++ b/qoolqit/waveforms/waveforms.py
@@ -50,7 +50,9 @@ class RampWaveform(Waveform):
         initial_value: float,
         final_value: float,
     ) -> None:
-        super().__init__(duration, initial_value=initial_value, final_value=final_value)
+        super().__init__(
+            duration, initial_value=float(initial_value), final_value=float(final_value)
+        )
 
     def function(self, t: float) -> float:
         fraction = t / self._duration
@@ -88,7 +90,7 @@ class ConstantWaveform(Waveform):
         duration: float,
         value: float,
     ) -> None:
-        super().__init__(duration, value=value)
+        super().__init__(duration, value=float(value))
 
     def function(self, t: float) -> float:
         return self.value
@@ -131,7 +133,7 @@ class BlackmanWaveform(Waveform):
 
     def __init__(self, duration: float, area: float) -> None:
         """Initializes a new BlackmanWaveform."""
-        super().__init__(duration, area=area)
+        super().__init__(duration, area=float(area))
 
     def function(self, t: float) -> float:
         alpha = 2 * math.pi / self.duration
@@ -178,6 +180,8 @@ class PiecewiseLinearWaveform(CompositeWaveform):
             if duration == 0.0:
                 raise ValueError("A PiecewiseLinearWaveform interval cannot have zero duration.")
 
+        # Stored as-is (not cast to float): unlike the per-segment RampWaveforms below,
+        # this attribute can retain an int dtype if `values` is int-typed.
         self.values = values
 
         wfs = [RampWaveform(dur, values[i], values[i + 1]) for i, dur in enumerate(durations)]

--- a/tests/test_waveforms/test_base_waveforms.py
+++ b/tests/test_waveforms/test_base_waveforms.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from pulser.waveforms import Waveform as PulserWaveform
 
-from qoolqit.waveforms import CompositeWaveform, Waveform
+from qoolqit.waveforms import CompositeWaveform, ConstantWaveform, RampWaveform, Waveform
 
 
 class TestWaveform:
@@ -78,6 +78,12 @@ class TestWaveform:
         with pytest.raises(ValueError, match="Duration needs to be a positive non-zero value."):
             self.MockWaveform(-10.0)
 
+    @pytest.mark.parametrize("duration", [1, 3])
+    def test_float_duration(self, duration: int) -> None:
+        mock_wf = self.MockWaveform(duration)
+        assert isinstance(mock_wf.duration, float)
+        assert mock_wf.duration == float(duration)
+
     def test_call_outside_duration(self) -> None:
         wf = self.MockWaveform(1.0)
 
@@ -105,6 +111,29 @@ class TestWaveform:
         result_array = wf(t_array)
         assert isinstance(result_array, np.ndarray)
         np.testing.assert_array_equal(result_array, np.array([wf.function(t) for t in t_array]))
+
+    def test_call_ndarray_matches_list_when_function_returns_int(self) -> None:
+        """Regression test for https://github.com/pasqal-io/qoolqit/issues/439.
+
+        `np.vectorize` infers the output dtype from the first call, so a waveform whose
+        first sampled value happens to be a Python int (e.g. `ConstantWaveform(1, 0)`)
+        must not cause later float samples to be truncated to int.
+        """
+        wf1 = ConstantWaveform(1, 0)
+        wf2 = RampWaveform(1, 0, -2)
+        wf_composed = wf1 >> wf2
+
+        n = 20
+        T = 2
+        t_array = np.linspace(0, T, n)
+        t_list = [i * T / (n - 1) for i in range(n)]
+
+        result_array = wf_composed(t_array)
+        result_list = wf_composed(t_list)
+
+        assert isinstance(result_array, np.ndarray)
+        assert result_array.dtype == np.float64
+        np.testing.assert_allclose(result_array, result_list, atol=1e-8)
 
     def test_composition(self) -> None:
         wf1 = self.MockWaveform(11.1)

--- a/tests/test_waveforms/test_derived_waveforms.py
+++ b/tests/test_waveforms/test_derived_waveforms.py
@@ -60,10 +60,17 @@ def test_delay_to_pulser() -> None:
     assert np.all(pulser_wf.samples == 0.0)
 
 
-def test_constant_init() -> None:
-    wf = ConstantWaveform(10.0, value=2.7)
-    assert wf.duration == 10.0
-    assert wf.value == 2.7
+@pytest.mark.parametrize("duration, value", [(1.57843, 2.7), (11.7, 3.4), (1, 2)])
+def test_constant_init(duration: float, value: float) -> None:
+    wf = ConstantWaveform(duration, value=value)
+    assert isinstance(wf.duration, float)
+    assert wf.duration == float(duration)
+    assert isinstance(wf.value, float)
+    assert wf.value == float(value)
+
+    # test single call
+    assert isinstance(wf(0.5), float)
+    assert wf(0.5) == float(value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Fixes #439: `np.vectorize` in `Waveform.__call__` inferred its output dtype from the first sample, silently truncating later float samples to int when that first value happened to be an int.
- Pins the vectorized output dtype to `float` and casts values to `float` at the points where they could leak as `int` (`_single_call`, `duration`, and the constructors of `ConstantWaveform`, `RampWaveform`, `BlackmanWaveform`).

## Test plan
- Added regression tests in `test_base_waveforms.py` and `test_derived_waveforms.py` covering the int-leak and the array/list sampling mismatch from the issue repro.
- Full test suite passes.