### PR TITLE
Scope graphs submodules

### DIFF
--- a/qoolqit/graphs/base_graph.py
+++ b/qoolqit/graphs/base_graph.py
@@ -1,3 +1,5 @@
+"""Base graph class on top of NetworkX: coordinates, weights, matrix conversion, unit-disk utils."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -6,6 +8,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
+import numpy.typing as npt
 from matplotlib.axes import Axes
 
 from .utils import (
@@ -18,12 +21,27 @@ from .utils import (
 
 
 class BaseGraph(nx.Graph):
-    """
-    The BaseGraph in QoolQit, directly inheriting from the NetworkX Graph.
+    """Base graph class, directly inheriting from the NetworkX Graph.
 
-    Defines basic functionalities for graphs within the Rydberg Analog, such
-    as instantiating from a set of node coordinates, directly accessing node
-    distances, and checking if the graph is unit-disk.
+    On top of the standard networkx.Graph functionalities, adds alternative
+    constructors, node coordinates and weights as first-class attributes,
+    distance and Rydberg-interaction calculations, unit-disk graph analysis,
+    and plotting.
+
+    Attributes:
+        coords: Dict mapping each node to its 2D coordinate, or None if unset.
+        node_weights: Dict mapping each node to its weight, or None if unset.
+        edge_weights: Dict mapping each edge to its weight, or None if unset.
+
+    Note:
+        Alternative constructors: `from_nodes`, `from_coordinates`, `from_nx`,
+        `from_matrix` (with its inverse `to_matrix`).
+        Coordinates and distances: `coords`, `distances`, `min_distance`,
+        `max_distance`, `rescale_coords`.
+        Unit-disk analysis: `is_ud_graph`, `ud_radius_range`, `ud_edges`,
+        `set_ud_edges`.
+        Rydberg-analog interactions: `interactions`, `interaction_matrix`.
+        Plotting: `draw`.
     """
 
     def __init__(self, edges: Iterable = []) -> None:
@@ -157,6 +175,75 @@ class BaseGraph(nx.Graph):
 
         return graph
 
+    @classmethod
+    def from_matrix(cls, data: npt.NDArray[np.float64]) -> BaseGraph:
+        """Constructs a graph from a symmetric square matrix.
+
+        The diagonal values are set as the node weights. For each entry (i, j)
+        where M[i, j] != 0 an edge (i, j) is added to the graph and the value
+        M[i, j] is set as its weight.
+
+        Arguments:
+            data: real symmetric square matrix.
+        """
+        if data.ndim != 2:
+            raise ValueError("2D Matrix required.")
+        if not np.allclose(data, data.T, rtol=0.0, atol=1e-7):
+            raise ValueError("Matrix must be symmetric.")
+
+        # Absolute values below this tolerance are treated as zeros.
+        # The corresponding node or edge weight is neglected (weight = None).
+        nonzero_tol = 1e-7
+
+        diag = np.diag(data)
+        n_nodes = len(diag)
+        if np.allclose(diag, np.zeros(n_nodes), rtol=0.0, atol=nonzero_tol):
+            node_weights = {i: None for i in range(n_nodes)}
+        else:
+            node_weights = {i: diag[i].item() for i in range(n_nodes)}
+
+        edge_list = [
+            (i, j)
+            for i in range(n_nodes)
+            for j in range(i + 1, n_nodes)
+            if (np.abs(data[i, j]) >= nonzero_tol)
+        ]
+        edge_weights = {(i, j): data[i, j].item() for i, j in edge_list}
+
+        graph = cls.from_nodes(range(n_nodes))
+        graph.add_edges_from(edge_list)
+        graph.node_weights = node_weights
+        graph.edge_weights = edge_weights
+        return graph
+
+    def to_matrix(self) -> npt.NDArray[np.float64]:
+        """Return the adjacency matrix of this graph.
+
+        The inverse of `from_matrix`.
+        Nodes are mapped to indices 0, ..., N-1 according to `self.nodes` insertion order.
+        - Node weights are stored in the diagonal since self-loops are not supported.
+            Nodes with no weight set (None) are left at 0.0 in the diagonal.
+        - For each edge (i, j), the entries (i,j) and (j,i) are set to its weight,
+            or to 1.0 if the edge has no weight set.
+
+        Returns:
+            Symmetric N x N matrix of dtype float64, where N is the number of nodes.
+        """
+        n_nodes = len(self.nodes)
+        index = {node: i for i, node in enumerate(self.nodes)}
+        matrix = np.zeros((n_nodes, n_nodes), dtype=np.float64)
+
+        for node, weight in self.node_weights.items():
+            if weight is not None:
+                i = index[node]
+                matrix[i, i] = weight
+
+        for (u, v), weight in self.edge_weights.items():
+            i, j = index[u], index[v]
+            matrix[i, j] = matrix[j, i] = weight if weight is not None else 1.0
+
+        return matrix
+
     @property
     def sorted_edges(self) -> set:
         """Returns the set of edges (u, v) such that (u < v)."""
@@ -199,6 +286,56 @@ class BaseGraph(nx.Graph):
         Requires all edges to have a weight.
         """
         return not ((None in self._edge_weights.values()) or len(self._edge_weights) == 0)
+
+    @property
+    def node_weights(self) -> dict:
+        """Return the dictionary of node weights."""
+        return self._node_weights
+
+    @node_weights.setter
+    def node_weights(self, weights: list | dict) -> None:
+        """Set the dictionary of node weights.
+
+        Arguments:
+            weights: list or dictionary of weights.
+        """
+        if isinstance(weights, list):
+            if len(weights) != self.number_of_nodes():
+                raise ValueError("Size of the weights list does not match the number of nodes.")
+            weights_dict = {i: w for i, w in zip(self.nodes, weights)}
+        elif isinstance(weights, dict):
+            nodes = set(weights.keys())
+            if set(self.nodes) != nodes:
+                raise ValueError(
+                    "Set of nodes in the given dictionary does not match the graph nodes."
+                )
+            weights_dict = weights
+        self._node_weights = weights_dict
+
+    @property
+    def edge_weights(self) -> dict:
+        """Return the dictionary of edge weights."""
+        return self._edge_weights
+
+    @edge_weights.setter
+    def edge_weights(self, weights: list | dict) -> None:
+        """Set the dictionary of edge weights.
+
+        Arguments:
+            weights: list or dictionary of weights.
+        """
+        if isinstance(weights, list):
+            if len(weights) != self.number_of_edges():
+                raise ValueError("Size of the weights list does not match the number of nodes.")
+            weights_dict = {i: w for i, w in zip(self.sorted_edges, weights)}
+        elif isinstance(weights, dict):
+            edges = set(weights.keys())
+            if set(self.sorted_edges) != edges:
+                raise ValueError(
+                    "Set of edges in the given dictionary does not match the graph ordered edges."
+                )
+            weights_dict = weights
+        self._edge_weights = weights_dict
 
     @property
     def coords(self) -> dict:

--- a/qoolqit/graphs/data_graph.py
+++ b/qoolqit/graphs/data_graph.py
@@ -1,7 +1,4 @@
-# TODO:
-# - refactor this to reuse common methods in constructors
-# - refactor using rescale_coords method
-
+"""Graph structure for problem data, with named topology constructors and PyG interchange."""
 
 from __future__ import annotations
 
@@ -10,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 import numpy as np
-import numpy.typing as npt
 
 from .base_graph import BaseGraph
 from .utils import random_coords
@@ -21,7 +17,24 @@ if TYPE_CHECKING:
 
 
 class DataGraph(BaseGraph):
-    """The main graph structure to represent problem data."""
+    """Graph structure to represent problem data.
+
+    Represents a simple graph (undirected and without self-loops), with
+    node coordinates and node/edge weights, distance and Rydberg-interaction
+    calculations, conversion to/from adjacency matrix, unit-disk graph
+    analysis, and plotting (inherited from BaseGraph). Adds named topology
+    constructors and conversion to/from PyTorch Geometric data objects.
+
+    Attributes:
+        coords: Dict mapping each node to its 2D coordinate, or None if unset.
+        node_weights: Dict mapping each node to its weight, or None if unset.
+        edge_weights: Dict mapping each edge to its weight, or None if unset.
+
+    Note:
+        Named topology constructors: `line`, `circle`, `triangular`,
+        `hexagonal`, `heavy_hexagonal`, `square`, `random_er`, `random_ud`.
+        PyTorch Geometric conversion: `from_pyg`, `to_pyg`.
+    """
 
     def __init__(self, edges: Iterable = []) -> None:
         """
@@ -253,75 +266,6 @@ class DataGraph(BaseGraph):
         graph.add_edges_from(edges)
         graph._reset_dicts()
         return graph
-
-    @classmethod
-    def from_matrix(cls, data: npt.NDArray[np.float64]) -> DataGraph:
-        """Constructs a graph from a symmetric square matrix.
-
-        The diagonal values are set as the node weights. For each entry (i, j)
-        where M[i, j] != 0 an edge (i, j) is added to the graph and the value
-        M[i, j] is set as its weight.
-
-        Arguments:
-            data: real symmetric square matrix.
-        """
-        if data.ndim != 2:
-            raise ValueError("2D Matrix required.")
-        if not np.allclose(data, data.T, rtol=0.0, atol=1e-7):
-            raise ValueError("Matrix must be symmetric.")
-
-        # Absolute values below this tolerance are treated as zeros.
-        # The corresponding node or edge weight is neglected (weight = None).
-        nonzero_tol = 1e-7
-
-        diag = np.diag(data)
-        n_nodes = len(diag)
-        if np.allclose(diag, np.zeros(n_nodes), rtol=0.0, atol=nonzero_tol):
-            node_weights = {i: None for i in range(n_nodes)}
-        else:
-            node_weights = {i: diag[i].item() for i in range(n_nodes)}
-
-        edge_list = [
-            (i, j)
-            for i in range(n_nodes)
-            for j in range(i + 1, n_nodes)
-            if (np.abs(data[i, j]) >= nonzero_tol)
-        ]
-        edge_weights = {(i, j): data[i, j].item() for i, j in edge_list}
-
-        graph = cls.from_nodes(range(n_nodes))
-        graph.add_edges_from(edge_list)
-        graph.node_weights = node_weights
-        graph.edge_weights = edge_weights
-        return graph
-
-    def to_matrix(self) -> npt.NDArray[np.float64]:
-        """Return the adjacency matrix of this graph.
-
-        The inverse of `from_matrix`.
-        Nodes are mapped to indices 0, ..., N-1 according to `self.nodes` insertion order.
-        - Node weights are stored in the diagonal since self-loops are not supported.
-            Nodes with no weight set (None) are left at 0.0 in the diagonal.
-        - For each edge (i, j), the entries (i,j) and (j,i) are set to its weight,
-            or to 1.0 if the edge has no weight set.
-
-        Returns:
-            Symmetric N x N matrix of dtype float64, where N is the number of nodes.
-        """
-        n_nodes = len(self.nodes)
-        index = {node: i for i, node in enumerate(self.nodes)}
-        matrix = np.zeros((n_nodes, n_nodes), dtype=np.float64)
-
-        for node, weight in self.node_weights.items():
-            if weight is not None:
-                i = index[node]
-                matrix[i, i] = weight
-
-        for (u, v), weight in self.edge_weights.items():
-            i, j = index[u], index[v]
-            matrix[i, j] = matrix[j, i] = weight if weight is not None else 1.0
-
-        return matrix
 
     @classmethod
     def from_pyg(
@@ -619,56 +563,6 @@ class DataGraph(BaseGraph):
             )
 
         return weights
-
-    @property
-    def node_weights(self) -> dict:
-        """Return the dictionary of node weights."""
-        return self._node_weights
-
-    @node_weights.setter
-    def node_weights(self, weights: list | dict) -> None:
-        """Set the dictionary of node weights.
-
-        Arguments:
-            weights: list or dictionary of weights.
-        """
-        if isinstance(weights, list):
-            if len(weights) != self.number_of_nodes():
-                raise ValueError("Size of the weights list does not match the number of nodes.")
-            weights_dict = {i: w for i, w in zip(self.nodes, weights)}
-        elif isinstance(weights, dict):
-            nodes = set(weights.keys())
-            if set(self.nodes) != nodes:
-                raise ValueError(
-                    "Set of nodes in the given dictionary does not match the graph nodes."
-                )
-            weights_dict = weights
-        self._node_weights = weights_dict
-
-    @property
-    def edge_weights(self) -> dict:
-        """Return the dictionary of edge weights."""
-        return self._edge_weights
-
-    @edge_weights.setter
-    def edge_weights(self, weights: list | dict) -> None:
-        """Set the dictionary of edge weights.
-
-        Arguments:
-            weights: list or dictionary of weights.
-        """
-        if isinstance(weights, list):
-            if len(weights) != self.number_of_edges():
-                raise ValueError("Size of the weights list does not match the number of nodes.")
-            weights_dict = {i: w for i, w in zip(self.sorted_edges, weights)}
-        elif isinstance(weights, dict):
-            edges = set(weights.keys())
-            if set(self.sorted_edges) != edges:
-                raise ValueError(
-                    "Set of edges in the given dictionary does not match the graph ordered edges."
-                )
-            weights_dict = weights
-        self._edge_weights = weights_dict
 
     def set_ud_edges(self, radius: float) -> None:
         """Reset the set of edges to be equal to the set of unit-disk edges."""

--- a/tests/test_graphs/test_base_graph.py
+++ b/tests/test_graphs/test_base_graph.py
@@ -249,6 +249,7 @@ def test_to_matrix_weighted(n_nodes: int) -> None:
 
 
 @pytest.mark.parametrize("n_nodes", [3, 7, 21])
+@pytest.mark.parametrize("seed", [12345, 5481], ids=[f"seed{i}" for i in range(2)])
 def test_to_matrix_roundtrip(n_nodes: int) -> None:
     rng = np.random.default_rng(12345)
     matrix = rng.normal(0, 1, size=(n_nodes, n_nodes))

--- a/tests/test_graphs/test_base_graph.py
+++ b/tests/test_graphs/test_base_graph.py
@@ -154,6 +154,136 @@ def test_basegraph_constructors(n_nodes: int) -> None:
     assert graph2.is_ud_graph()
 
 
+@pytest.mark.parametrize("n_nodes", [5, 10, 50])
+def test_from_matrix(n_nodes: int) -> None:
+    np.random.seed(0)
+    data = np.random.rand(n_nodes, n_nodes)
+
+    with pytest.raises(ValueError):
+        # Matrix is not symmetric
+        graph = BaseGraph.from_matrix(data)
+
+    data = data + data.T
+    data_copy = data.copy()  # Make a copy to test the original data
+
+    graph = BaseGraph.from_matrix(data)
+
+    # Check input data matrix has not been modified
+    np.testing.assert_equal(data, data_copy)
+
+    assert len(graph.node_weights) == graph.number_of_nodes()
+    assert len(graph.edge_weights) == graph.number_of_edges()
+    assert graph.has_node_weights
+    assert graph.has_edge_weights
+
+    data_diag = np.diag(data)
+    node_weights = list(graph.node_weights.values())
+    np.testing.assert_allclose(node_weights, data_diag)
+
+    # Build a fresh matrix for the second sub-test: zero out the diagonal and some random edges
+    almost_zero = 1e-14
+    data2 = data_copy.copy()
+    np.fill_diagonal(data2, almost_zero)
+    random_edges_removal = random_edge_list(range(n_nodes), k=4)
+    i_list, j_list = zip(*random_edges_removal)
+    data2[i_list, j_list] = almost_zero
+    data2[j_list, i_list] = almost_zero
+
+    graph = BaseGraph.from_matrix(data2)
+
+    assert not graph.has_node_weights
+    assert graph.has_edge_weights
+
+    for edge in random_edges_removal:
+        assert edge not in graph.sorted_edges
+
+    n_edges = graph.number_of_edges()
+    idx = [2 * i for i in range(n_edges)]
+
+    data_edge_weights = np.sort(data2[data2 >= 1e-7])[idx]
+    edge_weights = sorted(list(graph.edge_weights.values()))
+
+    np.testing.assert_allclose(edge_weights, data_edge_weights)
+
+
+@pytest.mark.parametrize("n_nodes", [5, 10, 50])
+def test_to_matrix_unweighted(n_nodes: int) -> None:
+    graph = BaseGraph.from_nodes(range(n_nodes))
+    graph.add_edges_from(random_edge_list(range(n_nodes), k=2 * n_nodes))
+    # FIXME: _edge_weights is a snapshot that goes stale after add_edges_from;
+    # see issue #431 (edge_weights does not reflect edges added after construction).
+    graph._reset_dicts()
+    assert not graph.has_node_weights
+    assert not graph.has_edge_weights
+
+    matrix = graph.to_matrix()
+
+    np.testing.assert_equal(matrix, matrix.T)
+    np.testing.assert_equal(np.diag(matrix), np.zeros(n_nodes))
+
+    for i, j in graph.sorted_edges:
+        assert matrix[i, j] == 1.0
+        assert matrix[j, i] == 1.0
+
+    non_edges = graph.all_node_pairs - graph.sorted_edges
+    for i, j in non_edges:
+        assert matrix[i, j] == 0.0
+        assert matrix[j, i] == 0.0
+
+
+@pytest.mark.parametrize("n_nodes", [5, 10, 50])
+def test_to_matrix_weighted(n_nodes: int) -> None:
+    graph = BaseGraph.from_nodes(range(n_nodes))
+    graph.add_edges_from(random_edge_list(range(n_nodes), k=2 * n_nodes))
+    graph.node_weights = {i: np.random.rand() for i in graph.nodes}
+    graph.edge_weights = {e: np.random.rand() for e in graph.sorted_edges}
+
+    matrix = graph.to_matrix()
+
+    np.testing.assert_equal(matrix, matrix.T)
+    np.testing.assert_allclose(np.diag(matrix), list(graph.node_weights.values()))
+
+    for (i, j), weight in graph.edge_weights.items():
+        assert matrix[i, j] == weight
+        assert matrix[j, i] == weight
+
+
+@pytest.mark.parametrize("n_nodes", [3, 7, 21])
+def test_to_matrix_roundtrip(n_nodes: int) -> None:
+    rng = np.random.default_rng(12345)
+    matrix = rng.normal(0, 1, size=(n_nodes, n_nodes))
+    # zero out some elements for testing
+    rows, cols = rng.integers(n_nodes, size=3), rng.integers(n_nodes, size=3)
+    matrix[rows, cols] = 0.0
+    matrix[cols, rows] = 0.0
+    matrix += matrix.T
+
+    graph = BaseGraph.from_matrix(matrix)
+    np.testing.assert_allclose(graph.to_matrix(), matrix, atol=1e-8)
+
+
+def test_to_matrix_custom_node_labels_and_none_weights() -> None:
+    # Ensure `to_matrix()` respects `self.nodes` ordering and handles None weights.
+    # Also ensures it works with non-0..N-1 node labels.
+    graph = BaseGraph.from_nodes(["b", "a", "c"])  # preserve explicit order
+    graph.add_edges_from([("b", "a"), ("a", "c")])
+
+    # Mix of real weights and None
+    graph.node_weights = {"b": 2.0, "a": None, "c": -3.0}
+    # NOTE: order is not guaranteed because BaseGraph maintains arbitrarily sorted edges
+    graph.edge_weights = {("a", "b"): None, ("a", "c"): 0.25}
+
+    matrix = graph.to_matrix()
+    expected = np.array(
+        [
+            [2.0, 1.0, 0.0],
+            [1.0, 0.0, 0.25],
+            [0.0, 0.25, -3.0],
+        ],
+    )
+    np.testing.assert_equal(matrix, expected)
+
+
 @pytest.mark.parametrize("input", ["hello", Data()])
 def test_from_nx_wrong_input(input: Any) -> None:
     with pytest.raises(TypeError, match="Input must be a networkx.Graph instance."):

--- a/tests/test_graphs/test_base_graph.py
+++ b/tests/test_graphs/test_base_graph.py
@@ -250,8 +250,8 @@ def test_to_matrix_weighted(n_nodes: int) -> None:
 
 @pytest.mark.parametrize("n_nodes", [3, 7, 21])
 @pytest.mark.parametrize("seed", [12345, 5481], ids=[f"seed{i}" for i in range(2)])
-def test_to_matrix_roundtrip(n_nodes: int) -> None:
-    rng = np.random.default_rng(12345)
+def test_to_matrix_roundtrip(n_nodes: int, seed: int) -> None:
+    rng = np.random.default_rng(seed)
     matrix = rng.normal(0, 1, size=(n_nodes, n_nodes))
     # zero out some elements for testing
     rows, cols = rng.integers(n_nodes, size=3), rng.integers(n_nodes, size=3)

--- a/tests/test_graphs/test_data_graph.py
+++ b/tests/test_graphs/test_data_graph.py
@@ -6,9 +6,7 @@ import pytest
 import torch
 from torch_geometric.data import Data
 
-from qoolqit.graphs import DataGraph, random_edge_list
-
-ATOL_64 = 1e-14
+from qoolqit.graphs import DataGraph
 
 
 @pytest.mark.parametrize("graph_type", ["circle", "line", "random_ud"])
@@ -65,131 +63,6 @@ def test_datagraph_random_er(n_nodes: int) -> None:
         graph.distances()
     with pytest.raises(AttributeError):
         graph.min_distance()
-
-
-@pytest.mark.parametrize("n_nodes", [5, 10, 50])
-def test_datagraph_from_matrix(n_nodes: int) -> None:
-    np.random.seed(0)
-    data = np.random.rand(n_nodes, n_nodes)
-
-    with pytest.raises(ValueError):
-        # Matrix is not symmetric
-        graph = DataGraph.from_matrix(data)
-
-    data = data + data.T
-    data_copy = data.copy()  # Make a copy to test the original data
-
-    graph = DataGraph.from_matrix(data)
-
-    # Check input data matrix has not been modified
-    np.testing.assert_equal(data, data_copy)
-
-    assert len(graph.node_weights) == graph.number_of_nodes()
-    assert len(graph.edge_weights) == graph.number_of_edges()
-    assert graph.has_node_weights
-    assert graph.has_edge_weights
-
-    data_diag = np.diag(data)
-    node_weights = list(graph.node_weights.values())
-    np.testing.assert_allclose(node_weights, data_diag)
-
-    # Build a fresh matrix for the second sub-test: zero out the diagonal and some random edges
-    almost_zero = ATOL_64
-    data2 = data_copy.copy()
-    np.fill_diagonal(data2, almost_zero)
-    random_edges_removal = random_edge_list(range(n_nodes), k=4)
-    i_list, j_list = zip(*random_edges_removal)
-    data2[i_list, j_list] = almost_zero
-    data2[j_list, i_list] = almost_zero
-
-    graph = DataGraph.from_matrix(data2)
-
-    assert not graph.has_node_weights
-    assert graph.has_edge_weights
-
-    for edge in random_edges_removal:
-        assert edge not in graph.sorted_edges
-
-    n_edges = graph.number_of_edges()
-    idx = [2 * i for i in range(n_edges)]
-
-    data_edge_weights = np.sort(data2[data2 >= 1e-7])[idx]
-    edge_weights = sorted(list(graph.edge_weights.values()))
-
-    np.testing.assert_allclose(edge_weights, data_edge_weights)
-
-
-@pytest.mark.parametrize("n_nodes", [5, 10, 50])
-def test_datagraph_to_matrix_unweighted(n_nodes: int) -> None:
-    graph = DataGraph.random_er(n_nodes, p=0.5, seed=0)
-    assert not graph.has_node_weights
-    assert not graph.has_edge_weights
-
-    matrix = graph.to_matrix()
-
-    np.testing.assert_equal(matrix, matrix.T)
-    np.testing.assert_equal(np.diag(matrix), np.zeros(n_nodes))
-
-    for i, j in graph.sorted_edges:
-        assert matrix[i, j] == 1.0
-        assert matrix[j, i] == 1.0
-
-    non_edges = graph.all_node_pairs - graph.sorted_edges
-    for i, j in non_edges:
-        assert matrix[i, j] == 0.0
-        assert matrix[j, i] == 0.0
-
-
-@pytest.mark.parametrize("n_nodes", [5, 10, 50])
-def test_datagraph_to_matrix_weighted(n_nodes: int) -> None:
-    graph = DataGraph.random_er(n_nodes, p=0.5, seed=0)
-    graph.node_weights = {i: np.random.rand() for i in graph.nodes}
-    graph.edge_weights = {e: np.random.rand() for e in graph.sorted_edges}
-
-    matrix = graph.to_matrix()
-
-    np.testing.assert_equal(matrix, matrix.T)
-    np.testing.assert_allclose(np.diag(matrix), list(graph.node_weights.values()))
-
-    for (i, j), weight in graph.edge_weights.items():
-        assert matrix[i, j] == weight
-        assert matrix[j, i] == weight
-
-
-@pytest.mark.parametrize("n_nodes", [3, 7, 21])
-def test_datagraph_to_matrix_roundtrip(n_nodes: int) -> None:
-    rng = np.random.default_rng(12345)
-    matrix = rng.normal(0, 1, size=(n_nodes, n_nodes))
-    # zero out some elements for testing
-    rows, cols = rng.integers(n_nodes, size=3), rng.integers(n_nodes, size=3)
-    matrix[rows, cols] = 0.0
-    matrix[cols, rows] = 0.0
-    matrix += matrix.T
-
-    graph = DataGraph.from_matrix(matrix)
-    np.testing.assert_allclose(graph.to_matrix(), matrix, atol=1e-8)
-
-
-def test_datagraph_to_matrix_custom_node_labels_and_none_weights() -> None:
-    # Ensure `to_matrix()` respects `self.nodes` ordering and handles None weights.
-    # Also ensures it works with non-0..N-1 node labels.
-    graph = DataGraph.from_nodes(["b", "a", "c"])  # preserve explicit order
-    graph.add_edges_from([("b", "a"), ("a", "c")])
-
-    # Mix of real weights and None
-    graph.node_weights = {"b": 2.0, "a": None, "c": -3.0}
-    # TOFIX: order is not guaranteed because DataGraph maintains arbitrarily sort edges
-    graph.edge_weights = {("a", "b"): None, ("a", "c"): 0.25}
-
-    matrix = graph.to_matrix()
-    expected = np.array(
-        [
-            [2.0, 1.0, 0.0],
-            [1.0, 0.0, 0.25],
-            [0.0, 0.25, -3.0],
-        ],
-    )
-    np.testing.assert_equal(matrix, expected)
 
 
 def test_triangular() -> None:


### PR DESCRIPTION
Add clear scope to graph submodules and update class docstring accordingly.

## Summary
- Move `node_weights`/`edge_weights` (get+set) and `from_matrix`/`to_matrix` from `DataGraph` to `BaseGraph`, since they only need dependencies `BaseGraph` already has (networkx/numpy).
- Keep `DataGraph` scoped to the named topology zoo (`line`, `circle`, `triangular`, `hexagonal`, `heavy_hexagonal`, `square`, `random_er`, `random_ud`) and PyTorch Geometric interchange (`from_pyg`/`to_pyg`), which pulls in an optional heavy dependency.
- Rewrite both class/module docstrings (Google style) to reflect the new scope, since `DataGraph` is the only publicly-exposed type.
- Relocate the corresponding `from_matrix`/`to_matrix` tests to `test_base_graph.py`.

Fixes #441