### PR TITLE
Naming of DataGraph.square and DataGraph.rectangular consistent with Register

### DIFF
--- a/docs/fundamentals/graphs.ipynb
+++ b/docs/fundamentals/graphs.ipynb
@@ -388,7 +388,7 @@
    "metadata": {},
    "source": [
     "### Square\n",
-    "A square lattice graph with m rows and n columns of square."
+    "A square lattice graph with m rows and m columns."
    ]
   },
   {
@@ -398,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph = DataGraph.square(m = 2, n = 2, spacing = 1.0)\n",
+    "graph = DataGraph.square(m = 2, spacing = 1.0)\n",
     "graph.draw()"
    ]
   },
@@ -551,7 +551,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "qoolqit",
+   "display_name": "devqoolqit (3.14.6)",
    "language": "python",
    "name": "python3"
   },
@@ -565,7 +565,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/qoolqit/graphs/data_graph.py
+++ b/qoolqit/graphs/data_graph.py
@@ -220,7 +220,8 @@ class DataGraph(BaseGraph):
         cls,
         m: int,
         n: int,
-        spacing: float = 1.0,
+        row_spacing: float = 1.0,
+        col_spacing: float = 1.0,
     ) -> DataGraph:
         """
         Constructs a rectangular lattice graph, with respective coordinates.
@@ -228,10 +229,11 @@ class DataGraph(BaseGraph):
         Arguments:
             m: Number of rows of rectangle.
             n: Number of columns of rectangle.
-            spacing: The distance between adjacent nodes on the final lattice.
+            row_spacing: distance between adjacent qubits in the row direction. Defaults to 1.0.
+            col_spacing: distance between adjacent qubits in the column direction. Defaults to 1.0.
         """
         G = nx.grid_2d_graph(m, n)
-        final_coords = [(x * spacing, y * spacing) for (x, y) in list(G.nodes)]
+        final_coords = [(x * row_spacing, y * col_spacing) for (x, y) in list(G.nodes)]
         G = nx.convert_node_labels_to_integers(G)
 
         graph = DataGraph.from_coordinates(final_coords)
@@ -252,7 +254,7 @@ class DataGraph(BaseGraph):
             m: Number of rows of the square.
             spacing: The distance between adjacent nodes on the final lattice.
         """
-        return cls.rectangular(m, m, spacing=spacing)
+        return cls.rectangular(m, m, row_spacing=spacing, col_spacing=spacing)
 
     @classmethod
     def random_ud(

--- a/qoolqit/graphs/data_graph.py
+++ b/qoolqit/graphs/data_graph.py
@@ -216,18 +216,18 @@ class DataGraph(BaseGraph):
         return graph
 
     @classmethod
-    def square(
+    def rectangular(
         cls,
         m: int,
         n: int,
         spacing: float = 1.0,
     ) -> DataGraph:
         """
-        Constructs a square lattice graph, with respective coordinates.
+        Constructs a rectangular lattice graph, with respective coordinates.
 
         Arguments:
-            m: Number of rows of square.
-            n: Number of columns of square.
+            m: Number of rows of rectangle.
+            n: Number of columns of rectangle.
             spacing: The distance between adjacent nodes on the final lattice.
         """
         G = nx.grid_2d_graph(m, n)
@@ -238,6 +238,21 @@ class DataGraph(BaseGraph):
         graph.add_edges_from(G.edges)
         graph._reset_dicts()
         return graph
+
+    @classmethod
+    def square(
+        cls,
+        m: int,
+        spacing: float = 1.0,
+    ) -> DataGraph:
+        """
+        Constructs a square lattice graph, with respective coordinates.
+
+        Arguments:
+            m: Number of rows of the square.
+            spacing: The distance between adjacent nodes on the final lattice.
+        """
+        return cls.rectangular(m, m, spacing=spacing)
 
     @classmethod
     def random_ud(

--- a/tests/test_graphs/test_data_graph.py
+++ b/tests/test_graphs/test_data_graph.py
@@ -136,8 +136,8 @@ def test_hexagonal() -> None:
     assert edges == expected_edges
 
 
-def test_square() -> None:
-    graph = DataGraph.square(4, 4, spacing=2.71)
+def test_rectangular() -> None:
+    graph = DataGraph.rectangular(4, 4, spacing=2.71)
 
     expected_coords = {
         0: (0.0, 0.0),

--- a/tests/test_graphs/test_data_graph.py
+++ b/tests/test_graphs/test_data_graph.py
@@ -137,7 +137,7 @@ def test_hexagonal() -> None:
 
 
 def test_rectangular() -> None:
-    graph = DataGraph.rectangular(4, 4, spacing=2.71)
+    graph = DataGraph.rectangular(4, 4, row_spacing=2.71, col_spacing=2.71)
 
     expected_coords = {
         0: (0.0, 0.0),


### PR DESCRIPTION
Renamed DataGraph.square() to DataGraph.rectangular(), added square(m) as a convenience method calling rectangular(m, m), and updated the tests accordingly.
