### PR TITLE
remove is_less_or_equal method

### DIFF
--- a/qoolqit/graphs/base_graph.py
+++ b/qoolqit/graphs/base_graph.py
@@ -14,7 +14,6 @@ from matplotlib.axes import Axes
 from .utils import (
     all_node_pairs,
     distances,
-    less_or_equal,
     scale_coords,
     space_coords,
 )
@@ -439,16 +438,22 @@ class BaseGraph(nx.Graph):
         except ValueError:
             return False
 
-    def ud_edges(self, radius: float) -> set:
-        """Returns the set of edges given by the intersection of circles of a given radius.
+    def ud_edges(self, radius: float, tol: float = 1e-7) -> set:
+        """Returns the set of edges whose distance is at most the given radius.
 
         Arguments:
-            radius: the value
+            radius: the unit-disk radius; a pair of nodes is included if their distance is at
+                most this value.
+            tol: numerical tolerance added to the radius to account for floating point error.
         """
-        if self.has_coords:
-            return set(e for e, d in self.distances().items() if less_or_equal(d, radius))
-        else:
-            raise AttributeError("Getting unit disk edges is not valid without coordinates.")
+        if radius < 0:
+            raise ValueError("`radius` must be a non-negative value.")
+        if not self.has_coords:
+            raise AttributeError(
+                "Trying to compute unit-disk edges for a graph without coordinates."
+            )
+
+        return set(e for e, d in self.distances().items() if d <= radius + tol)
 
     def rescale_coords(
         self,

--- a/qoolqit/graphs/utils.py
+++ b/qoolqit/graphs/utils.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import random
 from itertools import product
-from math import dist, hypot, isclose
+from math import dist, hypot
 from typing import Iterable
 
 import numpy as np
-
-ATOL_32 = 1e-7
 
 
 def all_node_pairs(nodes: Iterable) -> set:
@@ -78,8 +76,3 @@ def random_edge_list(nodes: Iterable, k: int) -> list:
     """Generates a random set of k edges linkings items from a set of nodes."""
     all_edges = all_node_pairs(nodes)
     return random.sample(tuple(all_edges), k=k)
-
-
-def less_or_equal(a: float, b: float, rel_tol: float = 0.0, abs_tol: float = ATOL_32) -> bool:
-    """Less or approximately equal."""
-    return a < b or isclose(a, b, rel_tol=rel_tol, abs_tol=abs_tol)


### PR DESCRIPTION
## Changes

This PR removes the less_or_equal helper from `qoolqit/graphs/utils.py` and inlines its logic directly into `BaseGraph.ud_edges` in [base_graph.py](vscode-webview://1ikoefsfigj35dtvv4c0ni4lfu995klrak9one71e11e3hfpmmhf/qoolqit/graphs/base_graph.py#L441-L456):

- ud_edges now takes an explicit tol parameter (default 1e-7) instead of relying on the removed isclose  helper, the comparison is now d <= radius + tol.
- Adds a validation that radius must be non-negative, raising ValueError otherwise.
- Cleaned up the docstring and error message for missing coordinates.
less_or_equal and its ATOL_32 constant are deleted from utils.py since ud_edges was their only caller.
## Test Plan
no new test added