### PR TITLE
Allow string aliases for CompilerProfile

### DIFF
--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -84,39 +84,48 @@ class QuantumProgram:
     def compile_to(
         self,
         device: Device,
-        profile: CompilerProfile = CompilerProfile.MAX_ENERGY,
+        profile: str | CompilerProfile = CompilerProfile.MAX_ENERGY,
         device_max_duration_ratio: float | None = None,
     ) -> None:
         """Compiles the quantum program for execution on a specific device.
 
-        The compilation process adapts the program to the device's constraints while
-        preserving the relative ratios of the original program parameters. Different
-        compilation profiles optimize for specific objectives:
+        The compilation process translates a program to make it runnable on a specific device:
 
-        - CompilerProfile.MAX_ENERGY (default): Scales the program to utilize the device's
+        - Dimensionalization: Rescale the drive amplitude and the register positions to
+            physical units compatible with the device.
+        - Translation: Translate the program to a lower-level representation (Pulser) that
+            can be executed on the device.
+
+        There are two compilation profiles:
+
+        - "max_energy" (default): Scale the program to utilize the device's
             maximum capabilities. The drive amplitude and the register positions are rescaled
             to achieve respectively the maximum amplitude and the minimum pairwise distance
             compatible with the input program and the device's constraints.
-        - CompilerProfile.WORKING_POINT: .
+        - "working_point": Compile the program as it is. The drive and the register positions
+            must respect the hardware constraints of the device which can be inspected
+            using `device.specs()`.
 
-        Further options DO NOT preserve the input program, but rather adapts the program to
-        the device's constraint. Programs compiled this way are not guaranteed to be portable
-        across devices.
+        The following option does NOT preserve the input program, but rather adapts the program
+        to the device's constraints. Programs compiled this way are not portable across devices.
 
         - device_max_duration_ratio: Rescale the drive duration to a fraction of the
-            device's maximum allowed duration.
-            This option is useful in adiabatic protocols where one simply seek to
-            minimize the time derivative of the drive's amplitude.
+            device's maximum allowed duration. Useful in adiabatic protocols where one simply
+            seeks to minimize the time derivative of the drive's amplitude.
 
         Args:
             device: The target device for compilation. Must be a QoolQit Device.
-            profile: The compilation strategy to optimize the program.
-                Defaults to CompilerProfile.MAX_ENERGY.
-            device_max_duration_ratio: Whether to set the program duration to a fraction of
-                the device's maximum allowed duration. Must be a number in the range (0, 1].
-                Can only be set if the device has a maximum allowed duration.
+            profile: The compilation profile used to translate the program.
+                Defaults to "max_energy".
+            device_max_duration_ratio: The fraction of the device's maximum allowed duration
+                to set the program duration to, or None to leave it unset. Must be a number
+                in the range (0, 1]. Can only be set if the device has a maximum allowed
+                duration.
 
         Raises:
+            TypeError: If `device` is not a QoolQit Device.
+            ValueError: If `device_max_duration_ratio` is set but the device has no maximum
+                allowed duration, or if it is not in the range (0, 1].
             CompilationError: If the compilation fails due to device constraints.
         """
         if not isinstance(device, Device):
@@ -140,6 +149,8 @@ class QuantumProgram:
                 raise CompilationError(
                     "The device does not support DMM. Please use a device that supports DMM."
                 )
+
+        profile = CompilerProfile(profile)
 
         compiler = SequenceCompiler(
             self.register, self.drive, device, profile, device_max_duration_ratio

--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from pulser.sequence.sequence import Sequence as PulserSequence
@@ -84,7 +86,9 @@ class QuantumProgram:
     def compile_to(
         self,
         device: Device,
-        profile: str | CompilerProfile = CompilerProfile.MAX_ENERGY,
+        profile: (
+            Literal["max_energy", "working_point"] | CompilerProfile
+        ) = CompilerProfile.MAX_ENERGY,
         device_max_duration_ratio: float | None = None,
     ) -> None:
         """Compiles the quantum program for execution on a specific device.
@@ -98,7 +102,7 @@ class QuantumProgram:
 
         There are two compilation profiles:
 
-        - "max_energy" (default): Scale the program to utilize the device's
+        - "max_energy": Scale the program to utilize the device's
             maximum capabilities. The drive amplitude and the register positions are rescaled
             to achieve respectively the maximum amplitude and the minimum pairwise distance
             compatible with the input program and the device's constraints.
@@ -116,7 +120,7 @@ class QuantumProgram:
         Args:
             device: The target device for compilation. Must be a QoolQit Device.
             profile: The compilation profile used to translate the program.
-                Defaults to "max_energy".
+                Defaults to CompilerProfile.MAX_ENERGY.
             device_max_duration_ratio: The fraction of the device's maximum allowed duration
                 to set the program duration to, or None to leave it unset. Must be a number
                 in the range (0, 1]. Can only be set if the device has a maximum allowed

--- a/tests/test_compilation/test_compile_to.py
+++ b/tests/test_compilation/test_compile_to.py
@@ -16,8 +16,11 @@ from qoolqit.execution.compilation_functions import CompilerProfile
 from qoolqit.waveforms import ConstantWaveform
 
 
-@pytest.mark.parametrize("profile", [CompilerProfile.MAX_ENERGY, CompilerProfile.WORKING_POINT])
-def test_compilation_single_qubit(profile: CompilerProfile) -> None:
+@pytest.mark.parametrize(
+    "profile",
+    [CompilerProfile.MAX_ENERGY, CompilerProfile.WORKING_POINT, "max_energy", "working_point"],
+)
+def test_compilation_single_qubit(profile: CompilerProfile | str) -> None:
     """Test compilation of a single-qubit program."""
     register = Register(qubits={"q0": (0.0, 0.0)})
     drive = Drive(amplitude=ConstantWaveform(2.0, 0.2))
@@ -26,6 +29,15 @@ def test_compilation_single_qubit(profile: CompilerProfile) -> None:
     # Test compilation on the default profile
     program.compile_to(device=AnalogDevice(), profile=profile)
     assert program.is_compiled
+
+
+def test_compile_to_invalid_profile_string() -> None:
+    """Test compilation with an invalid profile string alias."""
+    register = Register(qubits={"q0": (0.0, 0.0)})
+    drive = Drive(amplitude=ConstantWaveform(2.0, 0.2))
+    program = QuantumProgram(register=register, drive=drive)
+    with pytest.raises(ValueError, match="'bogus' is not a valid CompilerProfile"):
+        program.compile_to(device=AnalogDevice(), profile="bogus")
 
 
 def test_dmm_not_supported() -> None:

--- a/tests/test_compilation/test_compile_to.py
+++ b/tests/test_compilation/test_compile_to.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Literal
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -20,13 +21,14 @@ from qoolqit.waveforms import ConstantWaveform
     "profile",
     [CompilerProfile.MAX_ENERGY, CompilerProfile.WORKING_POINT, "max_energy", "working_point"],
 )
-def test_compilation_single_qubit(profile: CompilerProfile | str) -> None:
+def test_compilation_single_qubit(
+    profile: Literal["max_energy", "working_point"] | CompilerProfile,
+) -> None:
     """Test compilation of a single-qubit program."""
     register = Register(qubits={"q0": (0.0, 0.0)})
     drive = Drive(amplitude=ConstantWaveform(2.0, 0.2))
     program = QuantumProgram(register=register, drive=drive)
 
-    # Test compilation on the default profile
     program.compile_to(device=AnalogDevice(), profile=profile)
     assert program.is_compiled
 
@@ -37,7 +39,7 @@ def test_compile_to_invalid_profile_string() -> None:
     drive = Drive(amplitude=ConstantWaveform(2.0, 0.2))
     program = QuantumProgram(register=register, drive=drive)
     with pytest.raises(ValueError, match="'bogus' is not a valid CompilerProfile"):
-        program.compile_to(device=AnalogDevice(), profile="bogus")
+        program.compile_to(device=AnalogDevice(), profile="bogus")  # type: ignore [arg-type]
 
 
 def test_dmm_not_supported() -> None:


### PR DESCRIPTION
## Summary
- `QuantumProgram.compile_to` now accepts `profile` as either a `CompilerProfile` enum member or its string alias (e.g. `"max_energy"`, `"working_point"`), converting via `CompilerProfile(profile)` before compilation.
- Updated the `compile_to` docstring for accuracy (correct string values, complete `Raises` section) and clarity.
- Added test coverage for string-alias equivalence and invalid-string rejection in `test_compile_to.py`.

Progresses #455 by addressing its first sub-task ("Allow string aliases in CompilerProfile").