### PR TITLE
explicitly set compilation profile in tests and notebooks

### DIFF
--- a/docs/fundamentals/compilation/device_and_compilation.ipynb
+++ b/docs/fundamentals/compilation/device_and_compilation.ipynb
@@ -160,7 +160,7 @@
     "device = AnalogDevice()\n",
     "\n",
     "# Compilation to AnalogDevice\n",
-    "program.compile_to(device)\n",
+    "program.compile_to(device, profile=\"max_energy\")\n",
     "print(program)"
    ]
   },
@@ -226,7 +226,7 @@
    "outputs": [],
    "source": [
     "# Compilation to AnalogDevice max duration\n",
-    "program.compile_to(device, device_max_duration_ratio=1.0)\n",
+    "program.compile_to(device, profile=\"max_energy\", device_max_duration_ratio=1.0)\n",
     "program.draw(compiled = True)"
    ]
   },

--- a/docs/fundamentals/compilation/error_handling.ipynb
+++ b/docs/fundamentals/compilation/error_handling.ipynb
@@ -73,7 +73,7 @@
     ")\n",
     "\n",
     "device=AnalogDevice()\n",
-    "program.compile_to(device)"
+    "program.compile_to(device, profile=\"max_energy\")"
    ]
   },
   {
@@ -152,7 +152,7 @@
     "det=2\n",
     "program=create_program(L,amp,det)\n",
     "try:\n",
-    "    compiled_sequence = program.compile_to(device)\n",
+    "    compiled_sequence = program.compile_to(device, profile=\"max_energy\")\n",
     "except CompilationError as err:\n",
     "    print(err)"
    ]
@@ -186,7 +186,7 @@
     "det=20\n",
     "program=create_program(L,amp,det)\n",
     "try:\n",
-    "    compiled_sequence = program.compile_to(device)\n",
+    "    compiled_sequence = program.compile_to(device, profile=\"max_energy\")\n",
     "except CompilationError as err:\n",
     "    print(err)"
    ]
@@ -220,7 +220,7 @@
     "det=1\n",
     "program=create_program(L,amp,det)\n",
     "try:\n",
-    "    compiled_sequence = program.compile_to(device)\n",
+    "    compiled_sequence = program.compile_to(device, profile=\"max_energy\")\n",
     "except CompilationError as err:\n",
     "    print(err)"
    ]

--- a/docs/fundamentals/execution/execution.ipynb
+++ b/docs/fundamentals/execution/execution.ipynb
@@ -57,7 +57,7 @@
     "program = QuantumProgram(register, drive)\n",
     "\n",
     "# Compiling the program to a device\n",
-    "program.compile_to(device=AnalogDevice())"
+    "program.compile_to(device=AnalogDevice(), profile=\"max_energy\")"
    ]
   },
   {
@@ -427,7 +427,7 @@
     "from qoolqit.devices import Device\n",
     "\n",
     "device = Device.from_connection(connection, \"FRESNEL\")\n",
-    "program.compile_to(device=device)"
+    "program.compile_to(device=device, profile=\"max_energy\")"
    ]
   },
   {

--- a/docs/get_started/programming_with_qoolqit.ipynb
+++ b/docs/get_started/programming_with_qoolqit.ipynb
@@ -207,7 +207,7 @@
     "from qoolqit import AnalogDevice\n",
     "\n",
     "device = AnalogDevice()\n",
-    "program.compile_to(device)"
+    "program.compile_to(device, profile=\"max_energy\")"
    ]
   },
   {
@@ -315,8 +315,8 @@
     "program_no_blockade = QuantumProgram(register, drive_no_blockade)\n",
     "\n",
     "device = AnalogDevice()\n",
-    "program_blockade.compile_to(device)\n",
-    "program_no_blockade.compile_to(device)"
+    "program_blockade.compile_to(device, profile=\"max_energy\")\n",
+    "program_no_blockade.compile_to(device, profile=\"max_energy\")"
    ]
   },
   {

--- a/docs/tutorials/Critical_state_TFIM.ipynb
+++ b/docs/tutorials/Critical_state_TFIM.ipynb
@@ -355,7 +355,7 @@
    "outputs": [],
    "source": [
     "demo = build_program(80.0)\n",
-    "demo.compile_to(device)\n",
+    "demo.compile_to(device, profile=\"max_energy\")\n",
     "demo.draw(compiled=True)"
    ]
   },
@@ -677,7 +677,7 @@
     "for i, t in enumerate(t_sweep):\n",
     "    # Build the program at dimensionless duration t and compile it to the device.\n",
     "    prog = build_program(t)\n",
-    "    prog.compile_to(device)\n",
+    "    prog.compile_to(device, profile=\"max_energy\")\n",
     "\n",
     "    # Run the adiabatic evolution\n",
     "    emulator = LocalEmulator(backend_type=SVBackend, emulation_config=config)\n",
@@ -796,7 +796,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.6"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/Solving_a_MWIS.ipynb
+++ b/docs/tutorials/Solving_a_MWIS.ipynb
@@ -400,7 +400,7 @@
     "from qoolqit import MockDevice, QuantumProgram\n",
     "\n",
     "program = QuantumProgram(register, drive)\n",
-    "program.compile_to(device=MockDevice())\n",
+    "program.compile_to(device=MockDevice(), profile=\"max_energy\")\n",
     "program.draw()"
    ]
   },
@@ -508,7 +508,7 @@
     ")\n",
     "\n",
     "program_analog = QuantumProgram(register, drive_analog)\n",
-    "program_analog.compile_to(device=AnalogDeviceWithDMM())\n",
+    "program_analog.compile_to(device=AnalogDeviceWithDMM(), profile=\"max_energy\")\n",
     "\n",
     "results_analog = emulator.run(program_analog).results()\n",
     "counts_analog = results_analog.final_bitstrings\n",
@@ -550,7 +550,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mwis-tutorial (3.14.6)",
+   "display_name": "qoolqit",
    "language": "python",
    "name": "python3"
   },
@@ -564,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.6"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/solving_a_qubo.ipynb
+++ b/docs/tutorials/solving_a_qubo.ipynb
@@ -299,7 +299,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "program.compile_to(device=fresnel_device)"
+    "program.compile_to(device=fresnel_device, profile=\"max_energy\")"
    ]
   },
   {
@@ -422,7 +422,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "program.compile_to(device=fresnel_device, device_max_duration_ratio=1)\n",
+    "program.compile_to(device=fresnel_device, profile=\"max_energy\", device_max_duration_ratio=1)\n",
     "program.compiled_sequence.draw()"
    ]
   },

--- a/tests/test_execution/test_backends_integration.py
+++ b/tests/test_execution/test_backends_integration.py
@@ -7,6 +7,7 @@ from pulser.backend import Backend, Occupation
 from qoolqit import AnalogDevice, Drive, MockDevice, QuantumProgram, Register
 from qoolqit.devices import Device
 from qoolqit.execution import BackendType, EmulationConfig, JobStatus, LocalEmulator
+from qoolqit.execution.compilation_functions import CompilerProfile
 from qoolqit.waveforms import ConstantWaveform
 
 
@@ -24,7 +25,7 @@ def test_theoretical_state_vector(backend_type: Backend, rotation_angle: float) 
     # atoms far away, no interaction
     register = Register.from_coordinates([(-10, -10), (10, 10)])
     program = QuantumProgram(register, drive)
-    program.compile_to(device=MockDevice())
+    program.compile_to(device=MockDevice(), profile=CompilerProfile.MAX_ENERGY)
     emulation_config = EmulationConfig(observables=(Occupation(),))
     emulator = LocalEmulator(backend_type=backend_type, emulation_config=emulation_config)
     job = emulator.run(program)

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -9,6 +9,7 @@ from qoolqit import AnalogDevice, DigitalAnalogDevice, MockDevice
 from qoolqit.devices import Device
 from qoolqit.drive import DetuningMapModulator, Drive
 from qoolqit.exceptions import CompilationError
+from qoolqit.execution.compilation_functions import CompilerProfile
 from qoolqit.graphs import DataGraph
 from qoolqit.program import QuantumProgram
 from qoolqit.register import Register
@@ -53,7 +54,7 @@ def test_compiler_dmm(
         assert isinstance(program.compiled_sequence, PulserSequence)
     else:
         with pytest.raises(CompilationError):
-            program.compile_to(device)
+            program.compile_to(device, profile=CompilerProfile.MAX_ENERGY)
 
 
 def test_compiled_sequence_with_small_delays() -> None:
@@ -66,9 +67,9 @@ def test_compiled_sequence_with_small_delays() -> None:
     )
 
     program = QuantumProgram(register=register, drive=drive)
-    program.compile_to(device=AnalogDevice())
+    program.compile_to(device=AnalogDevice(), profile=CompilerProfile.MAX_ENERGY)
     program_small_delay = QuantumProgram(register=register, drive=drive_small_delay)
-    program_small_delay.compile_to(device=AnalogDevice())
+    program_small_delay.compile_to(device=AnalogDevice(), profile=CompilerProfile.MAX_ENERGY)
 
     # check that the delay is not added to the pulser sequence if small
     pulser_duration = program.compiled_sequence.get_duration()
@@ -91,7 +92,9 @@ def test_compile_to_max_duration_ratio(ratio: float) -> None:
 
     expected_max_duration = round(ratio * device._max_duration)
 
-    program.compile_to(device=device, device_max_duration_ratio=ratio)
+    program.compile_to(
+        device=device, profile=CompilerProfile.MAX_ENERGY, device_max_duration_ratio=ratio
+    )
     assert program.is_compiled
     assert program.compiled_sequence.get_duration() == expected_max_duration
 
@@ -116,7 +119,11 @@ def test_max_duration_ratio_error() -> None:
     program = QuantumProgram(register=register, drive=drive)
 
     with pytest.raises(ValueError, match="`device_max_duration_ratio` must be between 0 and 1,"):
-        program.compile_to(device=AnalogDevice(), device_max_duration_ratio=-0.1)
+        program.compile_to(
+            device=AnalogDevice(),
+            profile=CompilerProfile.MAX_ENERGY,
+            device_max_duration_ratio=-0.1,
+        )
 
     with pytest.raises(ValueError, match="Cannot set `device_max_duration_ratio`"):
         program.compile_to(device=MockDevice(), device_max_duration_ratio=0.5)


### PR DESCRIPTION
Following #455 

Some tests and some notebooks are implicitly relying on `max_energy` profile.
We can fix this here by explicitly setting the profile to be max energy.

This prevents fallout in the event of changing the default compilation strategy.

## Changes
Fixed the fallout from the default change: 9 test call sites (test_program.py, test_backends_integration.py) that relied on the old implicit MAX_ENERGY default now pass it explicitly, and 7 notebooks under docs/ that relied on it now pass profile="max_energy" explicitly to keep them runnable.