### PR TITLE
Follow up: fix compilation profile in program tests

### DIFF
--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -49,7 +49,7 @@ def test_compiler_dmm(
 ) -> None:
     program = dmm_program()
     if device._device.dmm_channels:
-        program.compile_to(device)
+        program.compile_to(device, profile=CompilerProfile.MAX_ENERGY)
         assert program.is_compiled
         assert isinstance(program.compiled_sequence, PulserSequence)
     else:
@@ -103,10 +103,12 @@ def test_compile_to_max_duration_ratio(ratio: float) -> None:
 def test_compile_to_max_duration(duration: float) -> None:
     """Test that the compiled sequence's duration is set to the maximum allowed by the device."""
     reg = Register.from_graph(DataGraph.line(2))
-    amp = ConstantWaveform(duration=duration, value=1.0)
+    amp = ConstantWaveform(duration=duration, value=0.2)
     drive = Drive(amplitude=amp)
     program = QuantumProgram(reg, drive)
-    program.compile_to(AnalogDevice(), device_max_duration_ratio=1.0)
+    program.compile_to(
+        AnalogDevice(), profile=CompilerProfile.WORKING_POINT, device_max_duration_ratio=1.0
+    )
 
     assert program.is_compiled
     assert program.compiled_sequence.get_duration() == 6000


### PR DESCRIPTION
Follow-up to #458, part of the work towards #455

## Description
Previous PR #458 did not update some `compile_to` calls in the test suite to explicitly set a profile.
This PR fixes the ones missed there.

## Changes
- Explicitly set the `CompilerProfile` in `tests/test_program.py` (`test_compiler_dmm`, `test_compile_to_max_duration`) instead of relying on the default, and adjust the amplitude value used in `test_compile_to_max_duration` accordingly.