### PR TITLE
add minimal blade documentation

### DIFF
--- a/docs/fundamentals/embedding.ipynb
+++ b/docs/fundamentals/embedding.ipynb
@@ -371,13 +371,7 @@
    "cell_type": "markdown",
    "id": "29",
    "metadata": {},
-   "source": [
-    "### Blade\n",
-    "\n",
-    "The **Balanced Latently Dimensional Embedder (BLaDE)** is a physics-inspired algorithm that, like the `InteractionEmbedder`, maps an interaction matrix or QUBO directly to node positions. It starts from a higher-dimensional embedding and progressively projects it down to the target number of dimensions, which helps it escape local minima and tends to produce higher quality embeddings than the spring-layout approach, at the cost of being slower to run.\n",
-    "\n",
-    "In QoolQit, the `Blade` embedder wraps this algorithm, mapping a `np.ndarray` to a `DataGraph` with coordinates, in the same way as the `InteractionEmbedder`."
-   ]
+   "source": "### Blade\n\nThe **Balanced Latently Dimensional Embedder (BLaDE)** is a physics-inspired algorithm that, like the `InteractionEmbedder`, maps an interaction matrix or QUBO directly to node positions. It starts from a higher-dimensional embedding and progressively projects it down to the target number of dimensions, which helps it escape local minima and tends to produce higher quality embeddings than the spring-layout approach, at the cost of being slower to run.\n\nIn QoolQit, the [`Blade`](/reference/embedding/#qoolqit.embedding.Blade) embedder wraps this algorithm, mapping a `np.ndarray` to a `DataGraph` with coordinates, in the same way as the `InteractionEmbedder`."
   },
   {
    "cell_type": "code",
@@ -399,11 +393,7 @@
    "cell_type": "markdown",
    "id": "31",
    "metadata": {},
-   "source": [
-    "The `BladeConfig` can also directly take a QoolQit `Device`, in which case it automatically sets the internal distance constraints so that the resulting embedding respects the device's hardware limitations.\n",
-    "\n",
-    "For a more complete, real-world example of embedding a QUBO with Blade, check out the [Blade tutorial](https://docs.pasqal.com/applicationsolvingtools/qubo/tutorial/05-blade) in the `qubo-solver` documentation."
-   ]
+   "source": "The [`BladeConfig`](/reference/embedding/#qoolqit.embedding.BladeConfig) can also directly take a QoolQit `Device`, in which case it automatically sets the internal distance constraints so that the resulting embedding respects the device's hardware limitations. See the API reference for `BladeConfig` for the full list of usage and arguments.\n\nFor a more complete, real-world example of embedding a QUBO with Blade, check out the [Blade tutorial](https://docs.pasqal.com/applicationsolvingtools/qubo/tutorial/05-blade) in the `qubo-solver` documentation."
   }
  ],
  "metadata": {

--- a/docs/fundamentals/embedding.ipynb
+++ b/docs/fundamentals/embedding.ipynb
@@ -56,6 +56,10 @@
     "## Available embedders\n",
     "Below, we will exemplify how to use some of the pre-defined concrete embedders directly available in QoolQit, and then show some considerations when defining custom embedders.\n",
     "\n",
+    "- [Interaction embedder](#interaction-embedder)\n",
+    "- [Spring-layout embedder](#spring-layout-embedder)\n",
+    "- [Blade](#blade)\n",
+    "\n",
     "### Interaction embedder\n",
     "Interaction embedding means to encode a matrix in the interaction term of the Rydberg analog model. For a matrix $U$, the goal is to find the set of coordinates that minimize\n",
     "\n",
@@ -369,7 +373,36 @@
    "metadata": {},
    "source": [
     "### Blade\n",
-    "Coming soon..."
+    "\n",
+    "The **Balanced Latently Dimensional Embedder (BLaDE)** is a physics-inspired algorithm that, like the `InteractionEmbedder`, maps an interaction matrix or QUBO directly to node positions. It starts from a higher-dimensional embedding and progressively projects it down to the target number of dimensions, which helps it escape local minima and tends to produce higher quality embeddings than the spring-layout approach, at the cost of being slower to run.\n",
+    "\n",
+    "In QoolQit, the `Blade` embedder wraps this algorithm, mapping a `np.ndarray` to a `DataGraph` with coordinates, in the same way as the `InteractionEmbedder`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qoolqit.embedding import Blade\n",
+    "\n",
+    "blade_embedder = Blade()\n",
+    "embedded_graph = blade_embedder.embed(A)\n",
+    "register = Register.from_graph(embedded_graph)\n",
+    "\n",
+    "register.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31",
+   "metadata": {},
+   "source": [
+    "The `BladeConfig` can also directly take a QoolQit `Device`, in which case it automatically sets the internal distance constraints so that the resulting embedding respects the device's hardware limitations.\n",
+    "\n",
+    "For a more complete, real-world example of embedding a QUBO with Blade, check out the [Blade tutorial](https://docs.pasqal.com/applicationsolvingtools/qubo/tutorial/05-blade) in the `qubo-solver` documentation."
    ]
   }
  ],
@@ -389,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Resolves #466 

Adds a minimal section to the documentation to cover a Blade example. 

- [x] Add section in docs/fundamentals/embedding.ipynb
- [x] Further link notebook in [qubo-solver documentation](https://docs.pasqal.com/applicationsolvingtools/qubo/tutorial/05-blade) (Pasqal docs portal). Make sure the notebook still exists in the new qubo-solver documentation.
