### PR TITLE
Expand ruff lint rule selection

### DIFF
--- a/docs/fundamentals/embedding.ipynb
+++ b/docs/fundamentals/embedding.ipynb
@@ -346,18 +346,7 @@
    "id": "27",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "n=6\n",
-    "graph_2 = DataGraph.circle(n)\n",
-    "for i,e in enumerate(graph_2.edge_weights):\n",
-    "    graph_2.edge_weights[e]= np.random.rand()\n",
-    "\n",
-    "embedded_graph_2 = embedder.embed(graph_2)\n",
-    "\n",
-    "fig, axs = plt.subplots(1, 2)\n",
-    "graph_2.draw(ax=axs[0])\n",
-    "embedded_graph_2.draw(ax=axs[1])"
-   ]
+   "source": "n=6\ngraph_2 = DataGraph.circle(n)\nfor e in graph_2.edge_weights:\n    graph_2.edge_weights[e]= np.random.rand()\n\nembedded_graph_2 = embedder.embed(graph_2)\n\nfig, axs = plt.subplots(1, 2)\ngraph_2.draw(ax=axs[0])\nembedded_graph_2.draw(ax=axs[1])"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,10 +107,25 @@ exclude_also = [
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "Q"]
+select = [
+    "E", # pycodestyle
+    "F", # Pyflakes
+    "Q", # flake8-quotes
+    "UP", # pyupgrade
+    "B", # flake8-bugbear
+    "SIM", # flake8-simplify
+    "I", # isort
+]
+ignore = [
+    "B905", # `zip()` without an explicit `strict=` parameter
+    "B008", # `np.random.default_rng` in argument defaults
+    "B018", # Found useless expression
+    "B024", # abstract base class with no abstract methods or properties
+    "B904", # raise exceptions with `raise ... from err` or `raise ... from None`
+    "SIM102", # Use a single `if` statement instead of nested `if` statements
+    "SIM211", # Use `not ...` instead of `False if ... else True`
+]
 isort.required-imports = ["from __future__ import annotations"]
-mccabe.max-complexity = 15
-flake8-quotes.docstring-quotes = "double"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]

--- a/qoolqit/devices/device.py
+++ b/qoolqit/devices/device.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 from dataclasses import replace
-from typing import Callable, Optional
 
 import pulser
 from pulser.backend.remote import RemoteConnection
@@ -62,7 +62,7 @@ class Device:
     def __init__(
         self,
         pulser_device: BaseDevice,
-        default_converter: Optional[UnitConverter] = None,
+        default_converter: UnitConverter | None = None,
     ) -> None:
 
         if not isinstance(pulser_device, BaseDevice):

--- a/qoolqit/embedding/algorithms/blade/_distances_constraints_calculator.py
+++ b/qoolqit/embedding/algorithms/blade/_distances_constraints_calculator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -94,7 +94,7 @@ class DistancesConstraintsCalculator:
 
     def compute_scaling_min_max(
         self, positions: np.ndarray, step_cursor: float, draw_differences: bool = False
-    ) -> tuple[float, Optional[float], Optional[float]]:
+    ) -> tuple[float, float | None, float | None]:
         """Computes the scaling and the new minimum and maximum distances.
 
         Computes the best scaling factor on the positions and the new

--- a/qoolqit/embedding/algorithms/blade/_force.py
+++ b/qoolqit/embedding/algorithms/blade/_force.py
@@ -92,7 +92,7 @@ class Force:
     def regulated(
         self,
         regulation_cursor: float = 0,
-    ) -> "Force":
+    ) -> Force:
         min_temperature = np.min(self.maximum_temperatures)
 
         if min_temperature != np.inf:

--- a/qoolqit/embedding/algorithms/blade/_helpers.py
+++ b/qoolqit/embedding/algorithms/blade/_helpers.py
@@ -9,7 +9,7 @@ FormatType = Literal["full", "triu", "sym"]
 
 
 def _format_return(input: Value, ret: np.ndarray, *, format: FormatType) -> Value:
-    if isinstance(input, float) or isinstance(input, int):
+    if isinstance(input, (float, int)):
         return float(ret)
 
     if input.ndim == 1:

--- a/qoolqit/embedding/algorithms/blade/_qubo_mapper.py
+++ b/qoolqit/embedding/algorithms/blade/_qubo_mapper.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Mapping, Sequence, Union
+from collections.abc import Mapping, Sequence
 
 import networkx as nx
 import numpy as np
 
-NodeId = Union[str, int]
+NodeId = str | int
 
 
 class Qubo:

--- a/qoolqit/embedding/algorithms/blade/blade.py
+++ b/qoolqit/embedding/algorithms/blade/blade.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import InitVar, dataclass
-from typing import Callable, Final
+from typing import Final
 
 import networkx as nx
 import numpy as np

--- a/qoolqit/embedding/algorithms/blade/drawing.py
+++ b/qoolqit/embedding/algorithms/blade/drawing.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 def eformat(f: Any) -> str:
     if 1 <= abs(f) < 1000:
         return f"{np.round(f, decimals=1)}"
-    elif 0.01 <= abs(f):
+    elif abs(f) >= 0.01:
         return f"{np.round(f, decimals=2)}"
     if f == 0:
         return "0"

--- a/qoolqit/embedding/base_embedder.py
+++ b/qoolqit/embedding/base_embedder.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import inspect
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from typing import Callable, Generic, TypeVar
+from typing import Generic, TypeVar
 
 
 @dataclass

--- a/qoolqit/execution/sequence_compiler.py
+++ b/qoolqit/execution/sequence_compiler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from pulser.sequence.sequence import Sequence as PulserSequence
 

--- a/qoolqit/graphs/base_graph.py
+++ b/qoolqit/graphs/base_graph.py
@@ -96,7 +96,7 @@ class BaseGraph(nx.Graph):
         num_edges = len(g.edges)
 
         # validate node attributes
-        for name, data in g.nodes.data():
+        for _name, data in g.nodes.data():
             unexpected_keys = set(data) - {"weight", "pos"}
             if unexpected_keys:
                 raise ValueError(f"{unexpected_keys} not allowed in node attributes.")
@@ -126,7 +126,7 @@ class BaseGraph(nx.Graph):
                     )
 
         # validate edge attributes
-        for u, v, data in g.edges.data():
+        for _u, _v, data in g.edges.data():
             unexpected_keys = set(data) - {"weight"}
             if unexpected_keys:
                 raise ValueError(f"{unexpected_keys} not allowed in edge attributes.")

--- a/qoolqit/graphs/utils.py
+++ b/qoolqit/graphs/utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Iterable
 from itertools import product
 from math import dist, hypot
-from typing import Iterable
 
 import numpy as np
 

--- a/qoolqit/program.py
+++ b/qoolqit/program.py
@@ -36,7 +36,7 @@ class QuantumProgram:
             raise TypeError("`drive` must be of type Drive.")
         if drive.dmm is not None:
             dmm_weights = drive.dmm.weights
-            for qid in dmm_weights.keys():
+            for qid in dmm_weights:
                 if qid not in register.qubits:
                     raise ValueError(
                         "In this QuantumProgram, the drive's detuning modulator map (DMM) "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Generator
 from random import uniform
-from typing import Callable, Generator
 
 import matplotlib
 

--- a/tests/test_compilation/test_default.py
+++ b/tests/test_compilation/test_default.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/tests/test_compilation/test_max_energy.py
+++ b/tests/test_compilation/test_max_energy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -74,9 +74,9 @@ def test_device_init_and_units(device: Device) -> None:
 
     device.reset_converter()
     TIME_NEW, ENERGY_NEW, DISTANCE_NEW = device.converter.factors
-    assert TIME_ORIG == pytest.approx(TIME_NEW)
-    assert ENERGY_ORIG == pytest.approx(ENERGY_NEW)
-    assert DISTANCE_ORIG == pytest.approx(DISTANCE_NEW)
+    assert pytest.approx(TIME_NEW) == TIME_ORIG
+    assert pytest.approx(ENERGY_NEW) == ENERGY_ORIG
+    assert pytest.approx(DISTANCE_NEW) == DISTANCE_ORIG
 
 
 def test_default_device_specs() -> None:

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from pulser.sequence import Sequence as PulserSequence


### PR DESCRIPTION
## Summary
- Widen `[tool.ruff.lint] select` from `E, F, I, Q` to also include `UP`, `B`, `SIM`, with a documented `ignore` list for the rules left for separate discussion (including `B905`, `zip()` without `strict=`).
- Fix the resulting findings that were addressed: unused loop variables, a redundant `isinstance` check, `dict.keys()` iteration, and several `pyupgrade`/typing modernizations (`Optional[X]` -> `X | None`, `typing.Callable` -> `collections.abc.Callable`, etc).
- Drop `mccabe.max-complexity` and `flake8-quotes.docstring-quotes` — both configure rule sets (`C90`, and docstring quoting under `D`) that aren't in `select`, so they were dead config.

## Rationale
#464 treats `pyproject.toml`'s ruff config as the single source of truth for linting and is about to add the `D` (docstring) rule set on top of it. Before piling more rules onto that config, this PR turns on the other rule categories ruff already ships that we weren't using yet, fixes the findings that are genuine cleanups, and ignores the rest (including `B905`) for now — so the next docstring-focused PR lands on an intentionally-configured baseline instead of an implicit one.

## To do next
To avoid a big diff, this MR left some ignored rules to fix
```toml
ignore = [
    "B905", # `zip()` without an explicit `strict=` parameter
    "B008", # `np.random.default_rng` in argument defaults
    "B018", # Found useless expression
    "B024", # abstract base class with no abstract methods or properties
    "B904", # raise exceptions with `raise ... from err` or `raise ... from None`
    "SIM102", # Use a single `if` statement instead of nested `if` statements
    "SIM211", # Use `not ...` instead of `False if ... else True`
]
```
To be fixed in a separate issue #474